### PR TITLE
Add Minecraft 26.1 support via Stonecutter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,10 @@ ij_formatter_tags_enabled = true
 
 [{*.kt,*.kts}]
 ktlint_code_style = intellij_idea
+ktlint_standard_comment-spacing = disabled
+ktlint_standard_import-ordering = disabled
+ktlint_standard_block-comment-initial-star-alignment = disabled
+ktlint_standard_comment-wrapping = disabled
 indent_size = 4
 ij_continuation_indent_size = 4
 ij_kotlin_align_in_columns_case_branch = false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,3 +106,15 @@ jobs:
         with:
           name: Artifacts-${{ matrix.version }}
           path: versions/${{ matrix.version }}/build/libs/
+      - name: capture test reports
+        # Upload server / client test outputs (logs, eula.txt, config) for
+        # post-mortem when CI fails. FabricGameTestRunner does not emit
+        # JUnit XML, so we ship the whole runtime dir.
+        if: ${{ always() && (matrix.task == 'runServertest' || matrix.task == 'runClienttest') }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: TestReports-${{ matrix.version }}-${{ matrix.task }}
+          path: |
+            versions/${{ matrix.version }}/build/servertest/
+            versions/${{ matrix.version }}/build/clienttest/
+          if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,9 @@ jobs:
           # Prevent OpenAL / SDL audio init crashes in headless CI clients.
           ALSOFT_DRIVERS: "null"
           SDL_AUDIODRIVER: "dummy"
+          # 26.1 Blaze3D requires a real OpenGL backend; Xvfb only provides
+          # software GLX, so force Mesa's llvmpipe software rasterizer.
+          LIBGL_ALWAYS_SOFTWARE: "1"
         with:
           run: ./gradlew :${{ matrix.version }}:${{ matrix.task }} --stacktrace
       - name: capture build artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,12 +48,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use these Java versions
-        java: [
-          21,    # Current Java LTS & minimum supported by Minecraft
-        ]
-        # Stonecutter-managed Minecraft versions. Add new versions here.
-        version: [ '1.21.11' ]
+        # Stonecutter-managed Minecraft versions. Each entry pins the JDK
+        # required by that Minecraft version (1.21.x = JDK 21, 26.1+ = JDK 25).
+        include:
+          - version: '1.21.11'
+            java: 21
+          - version: '26.1'
+            java: 25
         task: [ build, runServertest, runClienttest ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Stonecutter-managed Minecraft versions. Each entry pins the JDK
-        # required by that Minecraft version (1.21.x = JDK 21, 26.1+ = JDK 25).
+        # Full include cross product: mixing a base `task` axis with
+        # `include` entries that add new keys does NOT cross-multiply on
+        # GitHub Actions. Each MC version (1.21.x=JDK21, 26.1+=JDK25) is
+        # listed explicitly per task.
         include:
           - version: '1.21.11'
             java: 21
+            task: build
+          - version: '1.21.11'
+            java: 21
+            task: runServertest
+          - version: '1.21.11'
+            java: 21
+            task: runClienttest
           - version: '26.1'
             java: 25
-        task: [ build, runServertest, runClienttest ]
+            task: build
+          - version: '26.1'
+            java: 25
+            task: runServertest
+          - version: '26.1'
+            java: 25
+            task: runClienttest
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,15 +33,6 @@ jobs:
         with:
           msg: ${{ steps.rawtag.outputs.tag }}
           separator: '+'
-      - name: Setup java
-        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
-        with:
-          cache-disabled: true
       - name: Validate tag format and version mapping
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -62,6 +53,27 @@ jobs:
             exit 1
           fi
           echo "Tag OK: mod=${MOD_VERSION}, mc=${MC_VERSION}"
+      - name: Determine Java version for MC
+        id: jdk
+        env:
+          MC_VERSION: ${{ steps.tag.outputs._1 }}
+        run: |
+          set -euo pipefail
+          case "${MC_VERSION}" in
+            26.*) JAVA=25 ;;
+            *)    JAVA=21 ;;
+          esac
+          echo "java=${JAVA}" >> "$GITHUB_OUTPUT"
+          echo "Selected JDK ${JAVA} for MC ${MC_VERSION}"
+      - name: Setup java
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          java-version: ${{ steps.jdk.outputs.java }}
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
+        with:
+          cache-disabled: true
       - name: Build with Gradle
         run: ./gradlew :${{ steps.tag.outputs._1 }}:build
         env:
@@ -98,7 +110,7 @@ jobs:
           version: ${{ steps.tag.outputs._0 }}+${{ steps.tag.outputs._1 }}
           version-type: release
           changelog: ${{ steps.tag_message.outputs.message }}
-          java: 21
+          java: ${{ steps.jdk.outputs.java }}
           loaders: fabric
           game-versions: ${{ steps.tag.outputs._1 }}
           files: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,18 +3,19 @@ name: Publish on GitHub, CurseForge & Modrinth
 on:
   push:
     tags:
-      - "v*+*"
+      - "v*"
 
 permissions:
   contents: read
 
 concurrency:
-  group: publish-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
+  publish:
+    runs-on: ubuntu-24.04
+    environment: release
     permissions:
       contents: write
     steps:
@@ -22,97 +23,102 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - name: get release tag
-        id: rawtag
-        uses: olegtarasov/get-tag@9a8716825750e73195b02db42777b92ffe960605 # v2.1.4
-        with:
-          tagRegex: "v(.*)"
-      - name: Split tag version
-        uses: winterjung/split@d5c148c702e3aacdf08a98e33407c5af75d71e1e # v2.1.1-rc1
-        id: tag
-        with:
-          msg: ${{ steps.rawtag.outputs.tag }}
-          separator: '+'
-      - name: Validate tag format and version mapping
+          fetch-depth: 0
+      - name: Fetch tag object
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
-          MOD_VERSION: ${{ steps.tag.outputs._0 }}
-          MC_VERSION: ${{ steps.tag.outputs._1 }}
-        run: |
-          set -euo pipefail
-          if ! [[ "${GITHUB_REF_NAME}" =~ ^v[0-9A-Za-z._-]+\+[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-            echo "::error::Tag '${GITHUB_REF_NAME}' is not in the expected 'v<modver>+<mcver>' format (e.g. v0.0.1+1.21.11). The mod version must consist of [0-9A-Za-z._-]."
-            exit 1
-          fi
-          if [ -z "${MOD_VERSION}" ] || [ -z "${MC_VERSION}" ]; then
-            echo "::error::Failed to split tag into mod version ('${MOD_VERSION}') and Minecraft version ('${MC_VERSION}')."
-            exit 1
-          fi
-          if [ ! -f "versions/${MC_VERSION}/gradle.properties" ]; then
-            echo "::error::versions/${MC_VERSION}/gradle.properties not found. Make sure the Minecraft version is registered in settings.gradle.kts."
-            exit 1
-          fi
-          echo "Tag OK: mod=${MOD_VERSION}, mc=${MC_VERSION}"
-      - name: Determine Java version for MC
-        id: jdk
+        run: git fetch origin tag "$GITHUB_REF_NAME" --force
+      - name: Validate annotated tag
         env:
-          MC_VERSION: ${{ steps.tag.outputs._1 }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          set -euo pipefail
-          case "${MC_VERSION}" in
-            26.*) JAVA=25 ;;
-            *)    JAVA=21 ;;
-          esac
-          echo "java=${JAVA}" >> "$GITHUB_OUTPUT"
-          echo "Selected JDK ${JAVA} for MC ${MC_VERSION}"
-      - name: Setup java
-        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
-        with:
-          java-version: ${{ steps.jdk.outputs.java }}
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
-        with:
-          cache-disabled: true
-      - name: Build with Gradle
-        run: ./gradlew :${{ steps.tag.outputs._1 }}:build
+          TAG_TYPE=$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}")
+          if [ "$TAG_TYPE" != "tag" ]; then
+            echo "::error::Expected annotated tag but got ${TAG_TYPE}. Use 'git tag -a' to create an annotated tag with release notes in the message body."
+            exit 1
+          fi
+      - name: Validate secrets
         env:
-          MOD_VERSION: ${{ steps.tag.outputs._0 }}
-
+          MODRINTH_ID: ${{ secrets.MODRINTH_ID }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          CURSEFORGE_ID: ${{ secrets.CURSEFORGE_ID }}
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+        run: |
+          MISSING=""
+          [ -z "$MODRINTH_ID" ] && MISSING="${MISSING} MODRINTH_ID"
+          [ -z "$MODRINTH_TOKEN" ] && MISSING="${MISSING} MODRINTH_TOKEN"
+          [ -z "$CURSEFORGE_ID" ] && MISSING="${MISSING} CURSEFORGE_ID"
+          [ -z "$CURSEFORGE_TOKEN" ] && MISSING="${MISSING} CURSEFORGE_TOKEN"
+          if [ -n "$MISSING" ]; then
+            echo "::error::Missing required secrets:${MISSING}"
+            exit 1
+          fi
       - name: Get tag annotation message
         id: tag_message
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          # Get subject and body separately to exclude GPG signature
           TAG_SUBJECT=$(git tag -l --format='%(contents:subject)' "${GITHUB_REF_NAME}")
           TAG_BODY=$(git tag -l --format='%(contents:body)' "${GITHUB_REF_NAME}")
-          # Handle multi-line output using EOF delimiter
+          DELIMITER=$(openssl rand -hex 16)
           {
-            echo "message<<EOF"
-            echo "$TAG_SUBJECT"
+            printf "message<<%s\n" "$DELIMITER"
+            printf "%s\n" "$TAG_SUBJECT"
             if [ -n "$TAG_BODY" ]; then
-              echo ""
-              echo "$TAG_BODY"
+              printf "\n%s\n" "$TAG_BODY"
             fi
-            echo "EOF"
+            printf "%s\n" "$DELIMITER"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Publish to CurseForge/Modrinth
-        uses: Kir-Antipov/mc-publish@995edadc13559a8b28d0b7e6571229f067ec7659 # v3.3.0
+      - name: Extract version from tag
+        id: version
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: echo "mod_version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Setup Java
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          curseforge-id: ${{ secrets.CURSEFORGE_ID }}
-          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
-          modrinth-id: ${{ secrets.MODRINTH_ID }}
-          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
-          name: ${{ steps.rawtag.outputs.tag }}
-          version: ${{ steps.tag.outputs._0 }}+${{ steps.tag.outputs._1 }}
-          version-type: release
-          changelog: ${{ steps.tag_message.outputs.message }}
-          java: ${{ steps.jdk.outputs.java }}
-          loaders: fabric
-          game-versions: ${{ steps.tag.outputs._1 }}
-          files: |
-            versions/${{ steps.tag.outputs._1 }}/build/libs/fabpose-${{ steps.tag.outputs._0 }}+${{ steps.tag.outputs._1 }}.jar
-            versions/${{ steps.tag.outputs._1 }}/build/libs/fabpose-${{ steps.tag.outputs._0 }}+${{ steps.tag.outputs._1 }}-sources.jar
+          distribution: 'temurin'
+          java-version: |
+            21
+            25
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
+        with:
+          cache-disabled: true
+      - name: Build all versions
+        run: ./gradlew chiseledBuild
+        env:
+          MOD_VERSION: ${{ steps.version.outputs.mod_version }}
+          ORG_GRADLE_PROJECT_org.gradle.java.installations.fromEnv: JAVA_HOME_21_X64,JAVA_HOME_25_X64
+      - name: Publish to Modrinth and CurseForge
+        run: ./gradlew chiseledPublishMods
+        env:
+          MOD_VERSION: ${{ steps.version.outputs.mod_version }}
+          CHANGELOG: ${{ steps.tag_message.outputs.message }}
+          MODRINTH_ID: ${{ secrets.MODRINTH_ID }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          CURSEFORGE_ID: ${{ secrets.CURSEFORGE_ID }}
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+          ORG_GRADLE_PROJECT_org.gradle.java.installations.fromEnv: JAVA_HOME_21_X64,JAVA_HOME_25_X64
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          RELEASE_NOTES: ${{ steps.tag_message.outputs.message }}
+          MOD_VERSION: ${{ steps.version.outputs.mod_version }}
+        run: |
+          shopt -s nullglob
+          assets=()
+          for jar in versions/*/build/libs/fabpose-"${MOD_VERSION}"+*.jar; do
+            [[ "$jar" == *-sources.jar ]] && continue
+            assets+=("$jar")
+          done
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "::error::No release assets found matching versions/*/build/libs/fabpose-${MOD_VERSION}+*.jar"
+            exit 1
+          fi
+          echo "Found ${#assets[@]} release asset(s): ${assets[*]}"
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --notes "$RELEASE_NOTES" \
+            "${assets[@]}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Each Stonecutter-managed version uses one of two buildscripts, picked per versio
 - `build.fabric.gradle.kts` — obfuscated Fabric Loom pipeline (mappings + remap). Used for 1.21.x.
 - `build.fabric.unobfuscated.gradle.kts` — un-obfuscated Loom pipeline (no `mappings()`, plugin id `net.fabricmc.fabric-loom`). Used for 26.1+.
 
-The two scripts also pin different JDKs (1.21.x = JDK 21, 26.1+ = JDK 25); they are provisioned automatically by Gradle's `foojay-resolver-convention` toolchain plugin. The Nix dev shell (`flake.nix`) provides `Xvfb` (via `xorg-server`) and the `xvfb-run` wrapper for headless `runClienttest`; enter it with `nix develop` before invoking Gradle.
+The two scripts also pin different JDKs (1.21.x = JDK 21, 26.1+ = JDK 25); they are provisioned automatically by Gradle's `foojay-resolver-convention` toolchain plugin. The Nix dev shell (`flake.nix`) provides `Xvfb` (via `xorg-server`) for headless `runClienttest`, plus `gcc` for the 26.1 PulseAudio stub used to keep flite from aborting in headless environments. Both buildscripts disable Loom's built-in `xvfb-run` wrapping and start `Xvfb` themselves only for `runClienttest`. Enter the shell with `nix develop` before invoking Gradle.
 
 ## Key Development Commands
 
@@ -33,7 +33,7 @@ Build outputs land in `versions/<mc>/build/libs/`.
 
 ### Adding a new Minecraft version
 1. Add the version string to `versions(...)` in `settings.gradle.kts`. Pick the appropriate buildscript (`build.fabric.gradle.kts` for 1.21.x, `build.fabric.unobfuscated.gradle.kts` for 26.1+) via `versions("<mc>").buildscript("...")`.
-2. Create `versions/<new-mc>/gradle.properties` mirroring an existing one with `minecraft_version` / `loader_version` / `fabric_version` / `flk_version` adjusted.
+2. Create `versions/<new-mc>/gradle.properties` mirroring an existing one with `minecraft_version` / `loader_version` / `fabric_version` / `flk_version` / `java_version` adjusted. `java_version` is expanded into `fabric.mod.json` and must match the buildscript's JDK (21 for 1.21.x, 25 for 26.1+).
 3. Add the version to `matrix.include` in `.github/workflows/build.yml`, pinning the right JDK (21 for 1.21.x, 25 for 26.1+). Update the `case` in `publish.yml` (`Determine Java version for MC`) the same way.
 4. (Optional) Update the active version pointer in `stonecutter.gradle.kts` (`stonecutter active "<mc>"`) if you want IDE imports and bare `./gradlew build` to target the new version by default.
 5. Run `./gradlew :<new-mc>:build` to validate locally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Build outputs land in `versions/<mc>/build/libs/`.
 ### Adding a new Minecraft version
 1. Add the version string to `versions(...)` in `settings.gradle.kts`. Pick the appropriate buildscript (`build.fabric.gradle.kts` for 1.21.x, `build.fabric.unobfuscated.gradle.kts` for 26.1+) via `versions("<mc>").buildscript("...")`.
 2. Create `versions/<new-mc>/gradle.properties` mirroring an existing one with `minecraft_version` / `loader_version` / `fabric_version` / `flk_version` / `java_version` adjusted. `java_version` is expanded into `fabric.mod.json` and must match the buildscript's JDK (21 for 1.21.x, 25 for 26.1+).
-3. Add the version to `matrix.include` in `.github/workflows/build.yml`, pinning the right JDK (21 for 1.21.x, 25 for 26.1+). Update the `case` in `publish.yml` (`Determine Java version for MC`) the same way.
+3. Add the version to `matrix.include` in `.github/workflows/build.yml`, pinning the right JDK (21 for 1.21.x, 25 for 26.1+). If the new version requires a JDK that isn't already installed in `publish.yml` (currently 21 + 25), add it to the `setup-java` `java-version` list and to `ORG_GRADLE_PROJECT_org.gradle.java.installations.fromEnv` so the Gradle toolchain can resolve it.
 4. (Optional) Update the active version pointer in `stonecutter.gradle.kts` (`stonecutter active "<mc>"`) if you want IDE imports and bare `./gradlew build` to target the new version by default.
 5. Run `./gradlew :<new-mc>:build` to validate locally.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Each Stonecutter-managed version uses one of two buildscripts, picked per versio
 - `build.fabric.gradle.kts` — obfuscated Fabric Loom pipeline (mappings + remap). Used for 1.21.x.
 - `build.fabric.unobfuscated.gradle.kts` — un-obfuscated Loom pipeline (no `mappings()`, plugin id `net.fabricmc.fabric-loom`). Used for 26.1+.
 
-The two scripts also pin different JDKs (1.21.x = JDK 21, 26.1+ = JDK 25). The Nix dev shell (`flake.nix`) provides both JDKs and `xvfb-run`; enter it with `nix develop` before invoking Gradle.
+The two scripts also pin different JDKs (1.21.x = JDK 21, 26.1+ = JDK 25); they are provisioned automatically by Gradle's `foojay-resolver-convention` toolchain plugin. The Nix dev shell (`flake.nix`) provides `Xvfb` (via `xorg-server`) and the `xvfb-run` wrapper for headless `runClienttest`; enter it with `nix develop` before invoking Gradle.
 
 ## Key Development Commands
 
@@ -22,6 +22,7 @@ Stonecutter exposes a subproject per Minecraft version under `versions/<mc>`. Pr
 ```bash
 ./gradlew chiseledBuild              # Build every active version
 ./gradlew :1.21.11:build             # Build a specific version
+./gradlew :26.1:build                # Build the 26.1 (un-obfuscated) version
 ./gradlew :1.21.11:runServer         # Start development server
 ./gradlew :1.21.11:runClient         # Start development client
 ./gradlew :1.21.11:runServertest     # Run server-side tests
@@ -49,6 +50,7 @@ The `publish.yml` workflow validates the tag with the regex
 `^v[0-9A-Za-z._-]+\+[0-9]+\.[0-9]+(\.[0-9]+)?$` and uploads
 `versions/<mcver>/build/libs/fabpose-<modver>+<mcver>.jar` (and `-sources.jar`).
 The `<mcver>` segment must match an existing `versions/<mcver>/gradle.properties`.
+The JDK is selected automatically from the MC version (`26.*` → JDK 25, otherwise → JDK 21).
 
 ## Architecture Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,12 +45,16 @@ Build outputs land in `versions/<mc>/build/libs/`.
 ```
 
 ### Release Tags
-Releases are triggered by pushing tags matching `v<modver>+<mcver>` (e.g. `v1.4.2+1.21.11`).
-The `publish.yml` workflow validates the tag with the regex
-`^v[0-9A-Za-z._-]+\+[0-9]+\.[0-9]+(\.[0-9]+)?$` and uploads
-`versions/<mcver>/build/libs/fabpose-<modver>+<mcver>.jar` (and `-sources.jar`).
-The `<mcver>` segment must match an existing `versions/<mcver>/gradle.properties`.
-The JDK is selected automatically from the MC version (`26.*` → JDK 25, otherwise → JDK 21).
+Releases are triggered by pushing an **annotated** tag matching `v<modver>` (e.g. `git tag -a v1.4.2 -m "Release notes..."`). The `publish.yml` workflow requires the tag to be annotated (`git cat-file -t` must return `tag`) and uses its annotation message as the changelog for Modrinth, CurseForge, and the GitHub Release.
+
+A single tag publishes every Minecraft version registered in `settings.gradle.kts`:
+- `./gradlew chiseledBuild` builds all versions into `versions/<mcver>/build/libs/fabpose-<modver>+<mcver>.jar`.
+- `./gradlew chiseledPublishMods` uploads each artifact to Modrinth and CurseForge via the `me.modmuss50.mod-publish-plugin`. Each version becomes a separate Modrinth/CurseForge release tagged with the matching Minecraft version.
+- The GitHub Release attaches all built jars (`versions/*/build/libs/fabpose-<modver>+*.jar`, sources excluded).
+
+Required repository secrets: `MODRINTH_ID`, `MODRINTH_TOKEN`, `CURSEFORGE_ID`, `CURSEFORGE_TOKEN`. The workflow fails early if any are missing.
+
+Both JDK 21 (for 1.21.x) and JDK 25 (for 26.1+) are installed in the publish job; Gradle's toolchain plugin picks the right one per subproject via `org.gradle.java.installations.fromEnv`.
 
 ## Architecture Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,13 @@ FabPose is a Minecraft mod for Fabric servers that allows players to take variou
 
 The `main` branch manages modern Minecraft versions (1.21.11+) via [Stonecutter](https://stonecutter.kikugie.dev/). Legacy versions (1.21.10 and earlier) remain on their dedicated branches and are not Stonecutter-managed.
 
+Each Stonecutter-managed version uses one of two buildscripts, picked per version in `settings.gradle.kts`:
+
+- `build.fabric.gradle.kts` — obfuscated Fabric Loom pipeline (mappings + remap). Used for 1.21.x.
+- `build.fabric.unobfuscated.gradle.kts` — un-obfuscated Loom pipeline (no `mappings()`, plugin id `net.fabricmc.fabric-loom`). Used for 26.1+.
+
+The two scripts also pin different JDKs (1.21.x = JDK 21, 26.1+ = JDK 25). The Nix dev shell (`flake.nix`) provides both JDKs and `xvfb-run`; enter it with `nix develop` before invoking Gradle.
+
 ## Key Development Commands
 
 ### Build and Run
@@ -24,9 +31,9 @@ Stonecutter exposes a subproject per Minecraft version under `versions/<mc>`. Pr
 Build outputs land in `versions/<mc>/build/libs/`.
 
 ### Adding a new Minecraft version
-1. Add the version string to `versions(...)` in `settings.gradle.kts`.
+1. Add the version string to `versions(...)` in `settings.gradle.kts`. Pick the appropriate buildscript (`build.fabric.gradle.kts` for 1.21.x, `build.fabric.unobfuscated.gradle.kts` for 26.1+) via `versions("<mc>").buildscript("...")`.
 2. Create `versions/<new-mc>/gradle.properties` mirroring an existing one with `minecraft_version` / `loader_version` / `fabric_version` / `flk_version` adjusted.
-3. Add the version to `matrix.version` in `.github/workflows/build.yml`.
+3. Add the version to `matrix.include` in `.github/workflows/build.yml`, pinning the right JDK (21 for 1.21.x, 25 for 26.1+). Update the `case` in `publish.yml` (`Determine Java version for MC`) the same way.
 4. (Optional) Update the active version pointer in `stonecutter.gradle.kts` (`stonecutter active "<mc>"`) if you want IDE imports and bare `./gradlew build` to target the new version by default.
 5. Run `./gradlew :<new-mc>:build` to validate locally.
 

--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -202,8 +202,8 @@ tasks.jar {
 }
 
 publishMods {
-    file.set(tasks.jar.flatMap { it.archiveFile })
-    additionalFiles.from(tasks.named("sourcesJar").map { (it as Jar).archiveFile })
+    file.set(tasks.named("remapJar", org.gradle.api.tasks.bundling.AbstractArchiveTask::class).flatMap { it.archiveFile })
+    additionalFiles.from(tasks.named("remapSourcesJar", org.gradle.api.tasks.bundling.AbstractArchiveTask::class).flatMap { it.archiveFile })
     changelog.set(providers.environmentVariable("CHANGELOG").orElse(""))
     type.set(me.modmuss50.mpp.ReleaseType.STABLE)
     modLoaders.add("fabric")

--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -54,6 +54,7 @@ repositories {
 val loaderVersion = project.property("loader_version").toString()
 val fabricVersion = project.property("fabric_version").toString()
 val flkVersion = project.property("flk_version").toString()
+val javaVersion = project.property("java_version").toString()
 dependencies {
     // To change the versions see versions/<mc>/gradle.properties
     minecraft("com.mojang:minecraft:$minecraftVersion")
@@ -144,6 +145,7 @@ tasks.processResources {
         "fabric_version" to fabricVersion,
         "minecraft_version" to minecraftVersion,
         "flk_version" to flkVersion,
+        "java_version" to javaVersion,
     )
 
     filesMatching("fabric.mod.json") {
@@ -153,6 +155,7 @@ tasks.processResources {
             "fabric_version" to fabricVersion,
             "minecraft_version" to minecraftVersion,
             "flk_version" to flkVersion,
+            "java_version" to javaVersion,
         )
     }
 

--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -20,8 +20,6 @@ val serverTest = "servertest"
 val clientTest = "clienttest"
 sourceSets {
     val main by main
-    main.java.srcDirs(rootProject.file("src/main/java"))
-    main.resources.srcDirs(rootProject.file("src/main/resources"))
     val classPathConfig =
         closureOf<SourceSet> {
             compileClasspath += main.compileClasspath
@@ -29,14 +27,8 @@ sourceSets {
             runtimeClasspath += main.runtimeClasspath
             runtimeClasspath += main.output
         }
-    create(serverTest, classPathConfig).apply {
-        java.srcDirs(rootProject.file("src/$serverTest/java"))
-        resources.srcDirs(rootProject.file("src/$serverTest/resources"))
-    }
-    create(clientTest, classPathConfig).apply {
-        java.srcDirs(rootProject.file("src/$clientTest/java"))
-        resources.srcDirs(rootProject.file("src/$clientTest/resources"))
-    }
+    create(serverTest, classPathConfig)
+    create(clientTest, classPathConfig)
 }
 val serverTestSourceSet = sourceSets.getByName(serverTest)
 val clientTestSourceSet = sourceSets.getByName(clientTest)
@@ -163,6 +155,10 @@ tasks.processResources {
             "flk_version" to flkVersion,
         )
     }
+
+    // 26.1+ ships an additional AccessWidener with namespace `official`. It is unused
+    // (and rejected) by Loom on intermediary-mapped versions, so drop it from the jar.
+    exclude("fabpose.official.accesswidener")
 }
 
 tasks.withType<JavaCompile>().configureEach {
@@ -183,17 +179,6 @@ kotlin {
     jvmToolchain(21)
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
-    }
-    sourceSets {
-        named("main") {
-            kotlin.srcDirs(rootProject.file("src/main/kotlin"))
-        }
-        named(serverTest) {
-            kotlin.srcDirs(rootProject.file("src/$serverTest/kotlin"))
-        }
-        named(clientTest) {
-            kotlin.srcDirs(rootProject.file("src/$clientTest/kotlin"))
-        }
     }
 }
 

--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -1,6 +1,16 @@
 import java.util.concurrent.TimeUnit
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+// NOTE: This buildscript and build.fabric.unobfuscated.gradle.kts share large
+// structural overlap (sourceSets, configurations, processResources, Xvfb
+// handling). Intentional differences vs. unobfuscated: Loom plugin id
+// (`fabric-loom` vs `net.fabricmc.fabric-loom`), Loom version (1.14 vs 1.16),
+// `mappings(officialMojangMappings())`, `modImplementation`/`modLocalRuntime`,
+// Java/Kotlin target (21 vs 25), AccessWidener variant (`fabpose.accesswidener`
+// vs `fabpose.official.accesswidener`), permissions-api version (0.6.1 vs
+// 0.7.0), and PulseAudio stub / extra audio env (26.1 only). Keep behavioural
+// fixes (e.g., headless hardening) in sync across both files.
+
 plugins {
     id("fabric-loom") version "1.14-SNAPSHOT"
     id("maven-publish")

--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -308,5 +308,7 @@ tasks.named<JavaExec>(clientTestTaskName) {
 
         logger.lifecycle("Started Xvfb on display $display (pid: ${process.pid()})")
         environment("DISPLAY", display)
+        environment("ALSOFT_DRIVERS", "null")
+        environment("SDL_AUDIODRIVER", "dummy")
     }
 }

--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -272,6 +272,19 @@ val cleanupXvfbTask = tasks.register("cleanupXvfb") {
     }
 }
 
+// Disable Loom's built-in `xvfb-run` wrapping for every run task. We manage Xvfb
+// ourselves (only for runClienttest, see below). Without this, Loom auto-wraps
+// even runServertest with `xvfb-run` on Linux + CI environments, which crashes
+// when xvfb-run is not on PATH. `useXvfb` is protected in Loom 1.14, so go
+// through reflection (it became `public` in Loom 1.16+ via PR #1508 but we
+// keep one form that works on both).
+tasks.withType<net.fabricmc.loom.task.AbstractRunTask>().configureEach {
+    @Suppress("UNCHECKED_CAST")
+    val getter = javaClass.methods.firstOrNull { it.name == "getUseXvfb" }
+        ?: error("AbstractRunTask#getUseXvfb not found on ${javaClass.name}")
+    (getter.invoke(this) as org.gradle.api.provider.Property<Boolean>).set(false)
+}
+
 val clientTestTaskName = "run${clientTest.replaceFirstChar(Char::uppercaseChar)}"
 tasks.named<JavaExec>(clientTestTaskName) {
     finalizedBy(cleanupXvfbTask)

--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -13,9 +13,9 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("fabric-loom") version "1.14-SNAPSHOT"
-    id("maven-publish")
     kotlin("jvm") version "2.3.0"
     id("org.jmailen.kotlinter") version "5.2.0"
+    id("me.modmuss50.mod-publish-plugin") version "0.8.4"
 }
 
 val minecraftVersion = project.property("minecraft_version").toString()
@@ -201,20 +201,26 @@ tasks.jar {
     }
 }
 
-// configure the maven publication
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            from(components.getByName("java"))
-        }
-    }
+publishMods {
+    file.set(tasks.jar.flatMap { it.archiveFile })
+    additionalFiles.from(tasks.named("sourcesJar").map { (it as Jar).archiveFile })
+    changelog.set(providers.environmentVariable("CHANGELOG").orElse(""))
+    type.set(me.modmuss50.mpp.ReleaseType.STABLE)
+    modLoaders.add("fabric")
 
-    // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
-    repositories {
-        // Add repositories to publish to here.
-        // Notice: This block does NOT have the same function as the block in the top level.
-        // The repositories here will be used for publishing your artifact, not for
-        // retrieving dependencies.
+    modrinth {
+        projectId.set(providers.environmentVariable("MODRINTH_ID"))
+        accessToken.set(providers.environmentVariable("MODRINTH_TOKEN"))
+        minecraftVersions.add(minecraftVersion)
+        requires("fabric-api")
+        requires("fabric-language-kotlin")
+    }
+    curseforge {
+        projectId.set(providers.environmentVariable("CURSEFORGE_ID"))
+        accessToken.set(providers.environmentVariable("CURSEFORGE_TOKEN"))
+        minecraftVersions.add(minecraftVersion)
+        requires("fabric-api")
+        requires("fabric-language-kotlin")
     }
 }
 

--- a/build.fabric.unobfuscated.gradle.kts
+++ b/build.fabric.unobfuscated.gradle.kts
@@ -188,7 +188,7 @@ tasks.jar {
 
 publishMods {
     file.set(tasks.jar.flatMap { it.archiveFile })
-    additionalFiles.from(tasks.named("sourcesJar").map { (it as Jar).archiveFile })
+    additionalFiles.from(tasks.named<Jar>("sourcesJar").flatMap { it.archiveFile })
     changelog.set(providers.environmentVariable("CHANGELOG").orElse(""))
     type.set(me.modmuss50.mpp.ReleaseType.STABLE)
     modLoaders.add("fabric")

--- a/build.fabric.unobfuscated.gradle.kts
+++ b/build.fabric.unobfuscated.gradle.kts
@@ -267,32 +267,29 @@ tasks.named<JavaExec>(clientTestTaskName) {
     finalizedBy(cleanupXvfbTask)
 
     doFirst {
-        if (!needsXvfb()) return@doFirst
+        if (needsXvfb()) {
+            val xvfb = findXvfb() ?: error(
+                "No usable DISPLAY found and Xvfb is not installed. " +
+                    "Install Xvfb or run with a display server (e.g., xvfb-run ./gradlew $clientTestTaskName)",
+            )
 
-        val xvfb = findXvfb() ?: error(
-            "No usable DISPLAY found and Xvfb is not installed. " +
-                "Install Xvfb or run with a display server (e.g., xvfb-run ./gradlew $clientTestTaskName)",
-        )
+            val (process, display) = startXvfb(xvfb)
+            xvfbState.set(process)
+            val shutdownHook = Thread { if (process.isAlive) process.destroyForcibly() }
+            Runtime.getRuntime().addShutdownHook(shutdownHook)
 
-        val (process, display) = startXvfb(xvfb)
-        xvfbState.set(process)
-        val shutdownHook = Thread { if (process.isAlive) process.destroyForcibly() }
-        Runtime.getRuntime().addShutdownHook(shutdownHook)
+            logger.lifecycle("Started Xvfb on display $display (pid: ${process.pid()})")
+            environment("DISPLAY", display)
+        }
 
-        logger.lifecycle("Started Xvfb on display $display (pid: ${process.pid()})")
-        environment("DISPLAY", display)
         environment("ALSOFT_DRIVERS", "null")
         environment("SDL_AUDIODRIVER", "dummy")
         environment("PULSE_SERVER", "/dev/null")
-        // 26.1 Blaze3D requires an OpenGL backend. Xvfb only provides software GLX,
-        // so force Mesa's llvmpipe software rasterizer for headless test runs.
         environment("LIBGL_ALWAYS_SOFTWARE", "1")
-        // flite (TTS) calls pa_simple_write() without null-checking pa_simple_new()'s
-        // return value. When PulseAudio daemon is unavailable, that triggers
-        // `Assertion 'p' failed at simple.c:273` and SIGABRT before tests can run.
-        // Inject a stub libpulse-simple that returns dummy handles to keep flite alive.
         ensurePulseStub()?.let { stub ->
-            environment("LD_PRELOAD", stub.absolutePath)
+            val existing = System.getenv("LD_PRELOAD")
+            val ldPreload = if (existing.isNullOrBlank()) stub.absolutePath else "${stub.absolutePath}:$existing"
+            environment("LD_PRELOAD", ldPreload)
             logger.lifecycle("Using PulseAudio stub: ${stub.absolutePath}")
         }
     }
@@ -338,13 +335,21 @@ fun ensurePulseStub(): File? {
         int pa_simple_flush(void *p, int *e) { return 0; }
         """.trimIndent(),
     )
-    val result = ProcessBuilder("gcc", "-shared", "-fPIC", "-o", stubLib.absolutePath, stubSrc.absolutePath)
+    val tmpLib = File(stubDir, "libpulse-simple-stub.so.tmp")
+    if (tmpLib.exists()) tmpLib.delete()
+    val result = ProcessBuilder("gcc", "-shared", "-fPIC", "-o", tmpLib.absolutePath, stubSrc.absolutePath)
         .redirectErrorStream(true)
         .start()
     val output = result.inputStream.bufferedReader().readText()
     val exit = result.waitFor()
-    if (exit != 0 || !stubLib.exists()) {
+    if (exit != 0 || !tmpLib.exists()) {
         logger.warn("Failed to compile PulseAudio stub (exit $exit): $output")
+        tmpLib.delete()
+        return null
+    }
+    if (!tmpLib.renameTo(stubLib)) {
+        logger.warn("Failed to move compiled PulseAudio stub into place")
+        tmpLib.delete()
         return null
     }
     return stubLib

--- a/build.fabric.unobfuscated.gradle.kts
+++ b/build.fabric.unobfuscated.gradle.kts
@@ -281,5 +281,69 @@ tasks.named<JavaExec>(clientTestTaskName) {
 
         logger.lifecycle("Started Xvfb on display $display (pid: ${process.pid()})")
         environment("DISPLAY", display)
+        environment("ALSOFT_DRIVERS", "null")
+        environment("SDL_AUDIODRIVER", "dummy")
+        environment("PULSE_SERVER", "/dev/null")
+        // 26.1 Blaze3D requires an OpenGL backend. Xvfb only provides software GLX,
+        // so force Mesa's llvmpipe software rasterizer for headless test runs.
+        environment("LIBGL_ALWAYS_SOFTWARE", "1")
+        // flite (TTS) calls pa_simple_write() without null-checking pa_simple_new()'s
+        // return value. When PulseAudio daemon is unavailable, that triggers
+        // `Assertion 'p' failed at simple.c:273` and SIGABRT before tests can run.
+        // Inject a stub libpulse-simple that returns dummy handles to keep flite alive.
+        ensurePulseStub()?.let { stub ->
+            environment("LD_PRELOAD", stub.absolutePath)
+            logger.lifecycle("Using PulseAudio stub: ${stub.absolutePath}")
+        }
     }
+}
+
+/**
+ * Compile a stub libpulse-simple.so that returns dummy handles to prevent
+ * flite (TTS) from crashing with SIGABRT when PulseAudio daemon is unavailable.
+ * Returns null if gcc is not available (e.g., on minimal CI images), in which
+ * case the run task proceeds without LD_PRELOAD and may hit the assertion.
+ */
+fun ensurePulseStub(): File? {
+    val stubDir = layout.buildDirectory.dir("pulse-stub").get().asFile
+    val stubLib = File(stubDir, "libpulse-simple-stub.so")
+    if (stubLib.exists()) return stubLib
+
+    val hasGcc = runCatching {
+        ProcessBuilder("which", "gcc").redirectErrorStream(true).start().waitFor() == 0
+    }.getOrDefault(false)
+    if (!hasGcc) {
+        logger.warn("gcc not found on PATH; cannot build PulseAudio stub. " +
+            "runClienttest may abort with SIGABRT if PulseAudio daemon is reachable but unwritable.")
+        return null
+    }
+
+    stubDir.mkdirs()
+    val stubSrc = File(stubDir, "pulse_stub.c")
+    stubSrc.writeText(
+        """
+        #include <stddef.h>
+        void *pa_simple_new(const void *s, const char *n, int d,
+                            const char *dev, const char *sn,
+                            const void *ss, const void *map, int *e) {
+            static char dummy; return &dummy;
+        }
+        int pa_simple_write(void *p, const void *data, size_t bytes, int *e) { return 0; }
+        int pa_simple_drain(void *p, int *e) { return 0; }
+        void pa_simple_free(void *p) {}
+        int pa_simple_read(void *p, void *data, size_t bytes, int *e) { return 0; }
+        size_t pa_simple_get_latency(void *p, int *e) { return 0; }
+        int pa_simple_flush(void *p, int *e) { return 0; }
+        """.trimIndent(),
+    )
+    val result = ProcessBuilder("gcc", "-shared", "-fPIC", "-o", stubLib.absolutePath, stubSrc.absolutePath)
+        .redirectErrorStream(true)
+        .start()
+    val output = result.inputStream.bufferedReader().readText()
+    val exit = result.waitFor()
+    if (exit != 0 || !stubLib.exists()) {
+        logger.warn("Failed to compile PulseAudio stub (exit $exit): $output")
+        return null
+    }
+    return stubLib
 }

--- a/build.fabric.unobfuscated.gradle.kts
+++ b/build.fabric.unobfuscated.gradle.kts
@@ -1,6 +1,13 @@
 import java.util.concurrent.TimeUnit
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+// NOTE: This buildscript and build.fabric.gradle.kts share large structural
+// overlap. See the header of build.fabric.gradle.kts for the list of
+// intentional differences (Loom plugin id/version, mappings, configuration
+// names, Java/Kotlin target, AccessWidener variant, permissions-api version,
+// and the PulseAudio stub specific to this 26.1+ buildscript). Keep
+// behavioural fixes (e.g., headless hardening) in sync across both files.
+
 plugins {
     // 26.1+ ships un-obfuscated → use the new fabric-loom plugin id (no remap pipeline).
     id("net.fabricmc.fabric-loom") version "1.16-SNAPSHOT"

--- a/build.fabric.unobfuscated.gradle.kts
+++ b/build.fabric.unobfuscated.gradle.kts
@@ -313,8 +313,10 @@ fun ensurePulseStub(): File? {
         ProcessBuilder("which", "gcc").redirectErrorStream(true).start().waitFor() == 0
     }.getOrDefault(false)
     if (!hasGcc) {
-        logger.warn("gcc not found on PATH; cannot build PulseAudio stub. " +
-            "runClienttest may abort with SIGABRT if PulseAudio daemon is reachable but unwritable.")
+        logger.warn(
+            "gcc not found on PATH; cannot build PulseAudio stub. " +
+                "runClienttest may abort with SIGABRT if PulseAudio daemon is reachable but unwritable.",
+        )
         return null
     }
 

--- a/build.fabric.unobfuscated.gradle.kts
+++ b/build.fabric.unobfuscated.gradle.kts
@@ -49,6 +49,7 @@ repositories {
 val loaderVersion = project.property("loader_version").toString()
 val fabricVersion = project.property("fabric_version").toString()
 val flkVersion = project.property("flk_version").toString()
+val javaVersion = project.property("java_version").toString()
 dependencies {
     // To change the versions see versions/<mc>/gradle.properties
     minecraft("com.mojang:minecraft:$minecraftVersion")
@@ -134,6 +135,7 @@ tasks.processResources {
         "fabric_version" to fabricVersion,
         "minecraft_version" to minecraftVersion,
         "flk_version" to flkVersion,
+        "java_version" to javaVersion,
     )
 
     filesMatching("fabric.mod.json") {
@@ -143,6 +145,7 @@ tasks.processResources {
             "fabric_version" to fabricVersion,
             "minecraft_version" to minecraftVersion,
             "flk_version" to flkVersion,
+            "java_version" to javaVersion,
         )
     }
 

--- a/build.fabric.unobfuscated.gradle.kts
+++ b/build.fabric.unobfuscated.gradle.kts
@@ -11,9 +11,9 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     // 26.1+ ships un-obfuscated → use the new fabric-loom plugin id (no remap pipeline).
     id("net.fabricmc.fabric-loom") version "1.16-SNAPSHOT"
-    id("maven-publish")
     kotlin("jvm") version "2.3.0"
     id("org.jmailen.kotlinter") version "5.2.0"
+    id("me.modmuss50.mod-publish-plugin") version "0.8.4"
 }
 
 val minecraftVersion = project.property("minecraft_version").toString()
@@ -186,13 +186,26 @@ tasks.jar {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            from(components.getByName("java"))
-        }
+publishMods {
+    file.set(tasks.jar.flatMap { it.archiveFile })
+    additionalFiles.from(tasks.named("sourcesJar").map { (it as Jar).archiveFile })
+    changelog.set(providers.environmentVariable("CHANGELOG").orElse(""))
+    type.set(me.modmuss50.mpp.ReleaseType.STABLE)
+    modLoaders.add("fabric")
+
+    modrinth {
+        projectId.set(providers.environmentVariable("MODRINTH_ID"))
+        accessToken.set(providers.environmentVariable("MODRINTH_TOKEN"))
+        minecraftVersions.add(minecraftVersion)
+        requires("fabric-api")
+        requires("fabric-language-kotlin")
     }
-    repositories {
+    curseforge {
+        projectId.set(providers.environmentVariable("CURSEFORGE_ID"))
+        accessToken.set(providers.environmentVariable("CURSEFORGE_TOKEN"))
+        minecraftVersions.add(minecraftVersion)
+        requires("fabric-api")
+        requires("fabric-language-kotlin")
     }
 }
 

--- a/build.fabric.unobfuscated.gradle.kts
+++ b/build.fabric.unobfuscated.gradle.kts
@@ -1,0 +1,270 @@
+import java.util.concurrent.TimeUnit
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    // 26.1+ ships un-obfuscated → use the new fabric-loom plugin id (no remap pipeline).
+    id("net.fabricmc.fabric-loom") version "1.16-SNAPSHOT"
+    id("maven-publish")
+    kotlin("jvm") version "2.3.0"
+    id("org.jmailen.kotlinter") version "5.2.0"
+}
+
+val minecraftVersion = project.property("minecraft_version").toString()
+val modVersion = System.getenv("MOD_VERSION") ?: "0.0.0"
+base {
+    archivesName.set(project.property("archives_base_name") as? String)
+    version = "$modVersion+$minecraftVersion"
+    group = project.property("maven_group")!!
+}
+
+val serverTest = "servertest"
+val clientTest = "clienttest"
+sourceSets {
+    val main by main
+    val classPathConfig =
+        closureOf<SourceSet> {
+            compileClasspath += main.compileClasspath
+            compileClasspath += main.output
+            runtimeClasspath += main.runtimeClasspath
+            runtimeClasspath += main.output
+        }
+    create(serverTest, classPathConfig)
+    create(clientTest, classPathConfig)
+}
+val serverTestSourceSet = sourceSets.getByName(serverTest)
+val clientTestSourceSet = sourceSets.getByName(clientTest)
+
+configurations {
+    val implementation = "Implementation"
+    val testImplementation = testImplementation.get().exclude("org.slf4j", "slf4j-simple")
+    getByName("$serverTest$implementation").extendsFrom(testImplementation)
+    getByName("$clientTest$implementation").extendsFrom(testImplementation)
+}
+
+repositories {
+    maven("https://oss.sonatype.org/content/repositories/snapshots")
+    maven("https://api.modrinth.com/maven")
+}
+
+val loaderVersion = project.property("loader_version").toString()
+val fabricVersion = project.property("fabric_version").toString()
+val flkVersion = project.property("flk_version").toString()
+dependencies {
+    // To change the versions see versions/<mc>/gradle.properties
+    minecraft("com.mojang:minecraft:$minecraftVersion")
+    // 26.1+ is shipped un-obfuscated; no `mappings(...)` declaration needed.
+    implementation("net.fabricmc:fabric-loader:$loaderVersion")
+    compileOnly("com.mojang:authlib:3.13.56")
+
+    setOf(
+        "fabric-api-base",
+        "fabric-command-api-v2",
+        "fabric-events-interaction-v0",
+        // 1.21.11 still uses fabric-key-binding-api-v1; 26.1 renamed it to fabric-key-mapping-api-v1.
+        "fabric-key-mapping-api-v1",
+        "fabric-lifecycle-events-v1",
+        "fabric-networking-api-v1",
+        "fabric-registry-sync-v0",
+        "fabric-rendering-v1",
+        "fabric-object-builder-api-v1",
+        "fabric-gametest-api-v1",
+    ).forEach {
+        implementation(fabricApi.module(it, fabricVersion))
+    }
+    // For Gametests
+    runtimeOnly("net.fabricmc.fabric-api:fabric-api:$fabricVersion")
+    // Kotlin
+    implementation("net.fabricmc:fabric-language-kotlin:$flkVersion")
+    // Permissions API (un-obfuscated build that targets 26.1+)
+    implementation(include("me.lucko:fabric-permissions-api:0.7.0")!!)
+
+    testImplementation("io.kotest:kotest-runner-junit5:5.6.2")?.version?.also { kotestVersion ->
+        testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+        testImplementation("io.kotest:kotest-property:$kotestVersion")
+        testImplementation("io.kotest:kotest-framework-datatest:$kotestVersion")
+    }
+}
+
+loom {
+    accessWidenerPath.set(rootProject.file("src/main/resources/fabpose.official.accesswidener"))
+    runtimeOnlyLog4j.set(true)
+
+    runs {
+        create(serverTest) {
+            server()
+            configName = serverTest
+            vmArgs(
+                "-Dfabric-api.gametest",
+                "-Dfabric.api.gametest.report-file=${project.layout.buildDirectory.get()}/$name/junit.xml",
+            )
+            runDir = "build/$serverTest"
+            setSource(serverTestSourceSet)
+            isIdeConfigGenerated = true
+        }
+        create(clientTest) {
+            client()
+            configName = clientTest
+            vmArgs(
+                "-Dfabric-api.gametest",
+                "-Dfabric.api.gametest.report-file=${project.layout.buildDirectory.get()}/$name/junit.xml",
+            )
+            runDir = "build/$clientTest"
+            setSource(clientTestSourceSet)
+            isIdeConfigGenerated = true
+        }
+        create("manual$serverTest") {
+            server()
+            configName = "Manual $serverTest"
+            runDir = "build/$serverTest"
+            vmArgs("-Dfabric-api.gametest.command=true")
+            setSource(serverTestSourceSet)
+            isIdeConfigGenerated = true
+        }
+    }
+}
+
+tasks.withType<AbstractCopyTask>().configureEach {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
+tasks.processResources {
+    inputs.properties(
+        "loader_version" to loaderVersion,
+        "version" to project.version,
+        "fabric_version" to fabricVersion,
+        "minecraft_version" to minecraftVersion,
+        "flk_version" to flkVersion,
+    )
+
+    filesMatching("fabric.mod.json") {
+        expand(
+            "loader_version" to loaderVersion,
+            "version" to project.version,
+            "fabric_version" to fabricVersion,
+            "minecraft_version" to minecraftVersion,
+            "flk_version" to flkVersion,
+        )
+    }
+
+    // Use the un-obfuscated AccessWidener (namespace `official`) for 26.1+, exposing it
+    // under the canonical `fabpose.accesswidener` name referenced by fabric.mod.json.
+    exclude("fabpose.accesswidener")
+    rename("fabpose\\.official\\.accesswidener", "fabpose.accesswidener")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    // Minecraft 26.1+ requires Java 25
+    options.release = 25
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
+    withSourcesJar()
+}
+
+kotlin {
+    jvmToolchain(25)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_25)
+    }
+}
+
+tasks.jar {
+    from(rootProject.file("LICENSE")) {
+        rename { "${it}_${project.base.archivesName}" }
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components.getByName("java"))
+        }
+    }
+    repositories {
+    }
+}
+
+// Auto-start Xvfb for headless client test execution (Wayland / headless environments)
+val xvfbState = objects.property<Process>()
+
+fun needsXvfb(): Boolean {
+    val display = System.getenv("DISPLAY")
+    if (display.isNullOrBlank()) return true
+    if (display.contains(":") && !display.startsWith(":")) return false
+    val displayNum = display.removePrefix(":").takeWhile { it.isDigit() }
+    val socket = File("/tmp/.X11-unix/X$displayNum")
+    return !socket.exists()
+}
+
+fun findXvfb(): String? {
+    val candidates = listOf("Xvfb", "/usr/bin/Xvfb")
+    return candidates.firstOrNull { name ->
+        runCatching {
+            ProcessBuilder("which", name)
+                .redirectErrorStream(true)
+                .start()
+                .waitFor() == 0
+        }.getOrDefault(false)
+    }
+}
+
+fun startXvfb(xvfb: String): Pair<Process, String> {
+    for (displayNum in 99..199) {
+        val display = ":$displayNum"
+        if (File("/tmp/.X11-unix/X$displayNum").exists()) continue
+
+        val process = ProcessBuilder(xvfb, display, "-screen", "0", "1280x1024x24", "-nolisten", "tcp")
+            .redirectErrorStream(true)
+            .start()
+
+        val socketFile = File("/tmp/.X11-unix/X$displayNum")
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (!process.isAlive) break
+            if (socketFile.exists()) return process to display
+            Thread.sleep(100)
+        }
+
+        if (process.isAlive) process.destroyForcibly()
+    }
+    error("Failed to start Xvfb: no available display number in :99..:199")
+}
+
+val cleanupXvfbTask = tasks.register("cleanupXvfb") {
+    group = "verification"
+    description = "Stops the Xvfb process started for runClienttest, if any."
+    doLast {
+        xvfbState.orNull?.let { process ->
+            if (process.isAlive) {
+                logger.lifecycle("Stopping Xvfb (pid: ${process.pid()})")
+                process.destroy()
+                process.waitFor(5, TimeUnit.SECONDS)
+                if (process.isAlive) process.destroyForcibly()
+            }
+        }
+    }
+}
+
+val clientTestTaskName = "run${clientTest.replaceFirstChar(Char::uppercaseChar)}"
+tasks.named<JavaExec>(clientTestTaskName) {
+    finalizedBy(cleanupXvfbTask)
+
+    doFirst {
+        if (!needsXvfb()) return@doFirst
+
+        val xvfb = findXvfb() ?: error(
+            "No usable DISPLAY found and Xvfb is not installed. " +
+                "Install Xvfb or run with a display server (e.g., xvfb-run ./gradlew $clientTestTaskName)",
+        )
+
+        val (process, display) = startXvfb(xvfb)
+        xvfbState.set(process)
+        val shutdownHook = Thread { if (process.isAlive) process.destroyForcibly() }
+        Runtime.getRuntime().addShutdownHook(shutdownHook)
+
+        logger.lifecycle("Started Xvfb on display $display (pid: ${process.pid()})")
+        environment("DISPLAY", display)
+    }
+}

--- a/build.fabric.unobfuscated.gradle.kts
+++ b/build.fabric.unobfuscated.gradle.kts
@@ -247,6 +247,18 @@ val cleanupXvfbTask = tasks.register("cleanupXvfb") {
     }
 }
 
+// Disable Loom's built-in `xvfb-run` wrapping for every run task. We manage Xvfb
+// ourselves (only for runClienttest, see below). Without this, Loom auto-wraps
+// even runServertest with `xvfb-run` on Linux + CI environments, which crashes
+// when xvfb-run is not on PATH. Use reflection to keep one form that works
+// across Loom versions (`useXvfb` is `public` in 1.16+, `protected` in 1.14).
+tasks.withType<net.fabricmc.loom.task.AbstractRunTask>().configureEach {
+    @Suppress("UNCHECKED_CAST")
+    val getter = javaClass.methods.firstOrNull { it.name == "getUseXvfb" }
+        ?: error("AbstractRunTask#getUseXvfb not found on ${javaClass.name}")
+    (getter.invoke(this) as org.gradle.api.provider.Property<Boolean>).set(false)
+}
+
 val clientTestTaskName = "run${clientTest.replaceFirstChar(Char::uppercaseChar)}"
 tasks.named<JavaExec>(clientTestTaskName) {
     finalizedBy(cleanupXvfbTask)

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
             bashInteractive
             xrandr
             xorg-server # Provides Xvfb for headless client tests
-            xvfb-run # `xvfb-run` wrapper used by Loom 1.16's auto-xvfb integration
+            xvfb-run # Fallback wrapper for running Gradle tasks outside the buildscript-managed Xvfb path
             gcc # Required by build.fabric.unobfuscated.gradle.kts to compile the PulseAudio stub
             pinact
             zizmor

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
             bashInteractive
             xrandr
             xorg-server # Provides Xvfb for headless client tests
+            xvfb-run # `xvfb-run` wrapper used by Loom 1.16's auto-xvfb integration
             pinact
             zizmor
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             xrandr
             xorg-server # Provides Xvfb for headless client tests
             xvfb-run # `xvfb-run` wrapper used by Loom 1.16's auto-xvfb integration
+            gcc # Required by build.fabric.unobfuscated.gradle.kts to compile the PulseAudio stub
             pinact
             zizmor
           ];

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plans/stonecutter-migration-mc26.md
+++ b/plans/stonecutter-migration-mc26.md
@@ -406,8 +406,8 @@ FabPose/
   - `find . -type f | sort` で一致
   - AW (`fabpose.accesswidener`), mixins (`fabpose.mixins.json`) は完全一致
   - `fabric.mod.json` は `custom.loom:injected_interfaces` ブロックのみ削除 (cast 方式へ移行のため)
-- [ ] CI build job が `matrix.include=[1.21.11+JDK21, 26.1+JDK25]` で両方 green
-- [ ] CI publish job が `v0.0.0-test+26.1` の dry-run タグで validate 通過 (regex 確認)
+- [x] CI build job が `matrix.include=[1.21.11+JDK21, 26.1+JDK25]` で両方 green (PR #24 run 25991062993)
+- [ ] CI publish job が `v0.0.0-test+26.1` の dry-run タグで validate 通過 (regex 確認、本 PR では未実施)
 - [x] CLAUDE.md / AGENTS.md が新コマンド体系を反映
 - [ ] PR がレビュー承認され main にマージ
 

--- a/plans/stonecutter-migration-mc26.md
+++ b/plans/stonecutter-migration-mc26.md
@@ -59,10 +59,10 @@ stonecutter {
 
 librarian + explore 調査結果より、本 mod の 26.1 移行で対応が必要な項目:
 
-1. **`UseBlockCallback` → `BlockUseCallback`** にリネーム (1 ヒット: `src/main/java/net/fill1890/fabsit/FabSit.java`)
+1. ~~**`UseBlockCallback` → `BlockUseCallback`** にリネーム~~ → **実装結果**: 26.1 でも `UseBlockCallback` がそのまま生存しておりコンパイル成功。切替不要。
 2. **`fabric-key-binding-api-v1` → `fabric-key-mapping-api-v1`** モジュール名変更
 3. **`modImplementation` → `implementation`**, **`remapJar` → `jar`** (新 Loom)
-4. **fabric.mod.json `loom:injected_interfaces` の intermediary class 名 (class_1657 等) → Mojmap 名** (`net/minecraft/world/entity/player/Player` 等)。26.1 は un-obfuscated で intermediary 自体が無いため。
+4. ~~**fabric.mod.json `loom:injected_interfaces` の intermediary class 名 → Mojmap 名**~~ → **実装結果**: injected_interfaces 自体を**削除**し、利用箇所 (8 mixin Java ファイル) で explicit cast 方式 (`((PosingFlag) instance).fabSit$xxx()`) に統一。intermediary が無い 26.1 と obfuscated な 1.21.11 の両方で同一ソースから動くため、ブロック自体を消す方が単純。
 5. **Java 21 → Java 25** (toolchain)
 6. **Mixin ターゲット**: librarian 検証で全 31 クラス EXISTS 確認済 (Avatar/Mannequin は 25w36a で追加。AvatarRenderState 等も存続)。**コード変更不要**の見込み。
 7. **AccessWidener (`ClientboundPlayerInfoUpdatePacket entries`)**: フィールド存続。形式変更不要 (元から Mojmap)。
@@ -141,9 +141,9 @@ FabPose/
 - **失敗時**: Stonecutter 公式 docs (https://stonecutter.kikugie.dev/wiki/start/builds) を再読し、正しい構文を確定する。
 
 #### A-5. ベースライン jar 保存
-- **使用ツール**: `./gradlew :1.21.11:build` + `cp` で `temp/baseline-1.21.11-fabpose.jar` に保存
+- **使用ツール**: `./gradlew :1.21.11:build` + `cp` で `temp/baseline-1.21.11.jar` に保存
 - **手順**: 現状 (mc26 ブランチ作成直後 = main 状態) で 1.21.11 ビルドを実行し、jar を保存。実装後の DoD 検証で「1.21.11 jar が同等」確認に使用。
-- **期待結果**: `temp/baseline-1.21.11-fabpose.jar` 存在。`temp/` は .gitignore 済 (PR #23 で追加済)。
+- **期待結果**: `temp/baseline-1.21.11.jar` 存在。`temp/` は .gitignore 済 (PR #23 で追加済)。
 
 ### Phase B — settings.gradle.kts と buildscript 分離
 
@@ -207,12 +207,9 @@ FabPose/
 - **手順**: 1.21.11 版を雛形にして上記 16 点を適用。kotlin block と sourceSets block は 1.21.11 版から丸ごとコピー。
 - **QA**: `./gradlew :26.1:build --dry-run` で task graph が出ること。実 build はまだ失敗してよい。
 
-#### C-3. fabric.mod.json の `loom:injected_interfaces` を `?if` で切替
-- **使用ツール**: `read src/main/resources/fabric.mod.json` → `edit`
-- **変更**: JSON5 コメント形式の Stonecutter プリプロセッサで以下を切替:
-  - 1.21.11: 現行の `class_1657`, `class_2535`, `class_10055` (intermediary)
-  - 26.1: `net/minecraft/world/entity/player/Player`, `net/minecraft/network/Connection`, `net/minecraft/world/entity/decoration/Mannequin` (Mojmap)
-- **QA**: 1.21.11 ビルド後に `unzip -p versions/1.21.11/build/libs/*.jar fabric.mod.json | jq .custom` で 1.21.11 側の値が intermediary、26.1 ビルド後で同操作で Mojmap 値が取れること。
+#### C-3. fabric.mod.json の `loom:injected_interfaces` を削除し cast 方式へ移行
+- **実装結果**: 当初は `?if` 切替を予定していたが、より単純な解として `custom.loom:injected_interfaces` ブロック自体を削除し、利用箇所 (8 mixin Java ファイル) で explicit cast (`((PosingFlag) instance).fabSit$xxx()`) に書き換えた。これにより 1.21.11 / 26.1 双方で同一の fabric.mod.json が使える。
+- **QA**: 1.21.11 / 26.1 双方の jar の fabric.mod.json に `custom` キーが存在しないこと、両 build が成功すること。
 
 #### C-4. fabric.mod.json の depends 切替 (必要なら)
 - **使用ツール**: `read` で現在の depends 確認
@@ -226,11 +223,8 @@ FabPose/
 
 ### Phase D — Java/Kotlin ソースの 26.1 対応
 
-#### D-1. UseBlockCallback → BlockUseCallback の切替
-- **使用ツール**: `read src/main/java/net/fill1890/fabsit/FabSit.java` → Stonecutter `?if` で import と使用箇所を切替
-- **手順**: explore で 1 ヒットのみ確認済。該当 import 行と参照行に `//? if mc>="26.1" { ... //?} else { /*? if mc<"26.1" { ... }?*/ //?}` を入れる。
-- **検証要**: Stonecutter の version 比較構文 (`mc>="26.1"` か `>=26.1` か) は公式 docs に従う。
-- **QA**: 1.21.11 ビルドで現行コードが残ること、26.1 ビルドで `BlockUseCallback` 版が選択されること。`./gradlew :1.21.11:compileJava` と `:26.1:compileJava` 両方が成功。
+#### D-1. UseBlockCallback の動作確認
+- **実装結果**: `UseBlockCallback` は 26.1 でも生存していたためコード変更不要。`src/main/java/net/fill1890/fabsit/FabSit.java` は両 MC で同一コードのままコンパイル・ロード成功。当初想定していた `BlockUseCallback` への切替は不要。
 
 #### D-2. その他のコンパイルエラー対応 (random fix)
 - **使用ツール**: `./gradlew :26.1:compileJava :26.1:compileKotlin` を実行 → エラー出たら 1 件ずつ対応
@@ -278,7 +272,7 @@ FabPose/
 
 #### F-5. :1.21.11 ビルド jar non-regression diff
 - **使用ツール**: `./gradlew :1.21.11:build` + `unzip` + `jq` + `diff`
-- **手順**: ベースライン jar (`temp/baseline-1.21.11-fabpose.jar`、Phase A-5 で保存) と新 jar (`versions/1.21.11/build/libs/fabpose-...+1.21.11.jar`) を `/tmp/jar-compare/old` `/tmp/jar-compare/new` に解凍 → 以下の diff:
+- **手順**: ベースライン jar (`temp/baseline-1.21.11.jar`、Phase A-5 で保存) と新 jar (`versions/1.21.11/build/libs/fabpose-...+1.21.11.jar`) を `/tmp/jar-compare/old` `/tmp/jar-compare/new` に解凍 → 以下の diff:
   - `(cd /tmp/jar-compare/old && find . -type f | sort) > /tmp/old.list; (cd /tmp/jar-compare/new && find . -type f | sort) > /tmp/new.list; diff /tmp/old.list /tmp/new.list` でファイル一覧一致 (Stonecutter メタファイル追加は許容)
   - `diff <(jq -S 'del(.version)' /tmp/jar-compare/old/fabric.mod.json) <(jq -S 'del(.version)' /tmp/jar-compare/new/fabric.mod.json)` で fabric.mod.json 一致
   - `diff /tmp/jar-compare/old/fabpose.mixins.json /tmp/jar-compare/new/fabpose.mixins.json` で mixins 設定一致

--- a/plans/stonecutter-migration-mc26.md
+++ b/plans/stonecutter-migration-mc26.md
@@ -1,0 +1,439 @@
+# Stonecutter Migration: Add Minecraft 26.1 Support
+
+**ステータス**: 計画段階 (branch `feat/stonecutter-mc26`)。実装前。Momus 承認待ち → ユーザー承認 → 実装着手。
+
+**前提となる完了済み作業**: PR #23 (`Introduce Stonecutter` series, 1d443dbd) で 1.21.11 単一バージョンの Stonecutter 化は shipped。本計画はその上に **26.1 を 2 つ目のバージョンとして追加**する。
+
+---
+
+## 0. ゴール / 非ゴール
+
+### ゴール
+- Minecraft 26.1 を Stonecutter 管理対象に追加する。`./gradlew :26.1:build` と `./gradlew chiseledBuild` の両方で 1.21.11 / 26.1 双方の jar が生成できる。
+- 1.21.11 ビルドは PR #23 と完全に**同等**の挙動 (jar 内容、CI、release 経路) を維持する。
+- 26.1 ビルドは公式 26.1 の **non-obfuscated 開発フロー** (`net.fabricmc.fabric-loom` plugin id, Java 25, Loom 1.16+, modImplementation→implementation, remapJar→jar) に準拠する。
+- 1.21.11 と 26.1 の **buildscript を完全分離** する: `build.fabric.gradle.kts` (1.21.11, 旧 fabric-loom plugin id) / `build.fabric.unobfuscated.gradle.kts` (26.1+, 新 net.fabricmc.fabric-loom plugin id)。
+- CI matrix で両バージョンを並行ビルド・テストする。
+- リリースタグ `v<modver>+26.1` で 26.1 jar が GitHub Release に publish される。
+
+### 非ゴール (本 PR スコープ外)
+- 1.21.10 以前の旧バージョン (legacy グループ) の Stonecutter 化。別計画書で扱う (未作成)。
+- 既存の MannequinEntity システムの 26.1 バニラ Mannequin への置き換え。26.1 でも引き続き mod 独自の MannequinEntity を使用する (本計画は「ビルドが通って既存挙動が維持される」までを目指す)。
+- 1.21.11 の Java/Loom/Loader 等のバージョンアップ。
+- 26.2 以降への追加対応 (本計画は 26.1 のみ)。
+- 既存ブランチ群 (1.21.10, 1.21.7 等) の整理。
+
+---
+
+## 1. 前提と制約
+
+### 1.1 アーキテクチャ上の制約
+
+**26.1 と 1.21.11 では Loom plugin id が異なる**。
+- 1.21.11: `id("fabric-loom") version "1.14-SNAPSHOT"` (旧 plugin id, obfuscated mappings ベース、Mojmap mapping を `loom.officialMojangMappings()` 経由で取得)
+- 26.1: `id("net.fabricmc.fabric-loom") version "1.16-SNAPSHOT"` (新 plugin id, non-obfuscated, mapping 不要)
+
+> **検証要 (実装時)**: Loom 1.16-SNAPSHOT の最新バージョン (1.17.0-alpha.x の可能性あり) と plugin id (`net.fabricmc.fabric-loom` が正式) を実装着手時に Maven で再確認する。本計画では便宜上「Loom 1.16-SNAPSHOT (新 plugin id)」と表記するが、実装時に最新安定/snapshot に追従する。
+
+これらは単一の `plugins {}` ブロック内で `?if` プリプロセッサ切り替えできない (Gradle の plugins ブロックは静的解析される)。**Stonecutter の per-version `buildscript()` 機能で物理的に build script を分離する**のが推奨パターン (librarian で公式 docs および fabric-permissions-api 等の OSS 実例を確認済)。
+
+### 1.2 Stonecutter buildscript 分離の構文
+
+settings.gradle.kts:
+```kotlin
+stonecutter {
+    kotlinController = true
+    // centralScript は per-version buildscript 指定があるバージョンには適用されない
+    centralScript = "build.gradle.kts"  // fallback (使われない想定)
+    create(rootProject) {
+        versions("1.21.11").buildscript("build.fabric.gradle.kts")
+        versions("26.1").buildscript("build.fabric.unobfuscated.gradle.kts")
+        vcsVersion = "1.21.11"
+    }
+}
+```
+
+> **検証要 (実装時)**: 上記構文 (`versions("X").buildscript("Y.kts")`) は librarian 調査で HIGH confidence と回答されたが、実際の挙動 (ファイルが見つからないとどう失敗するか、各 version subproject から見える working directory はどこか) は実装時に最小再現で確認する。万一構文が異なる場合 (例: `vers(...)` / 引数順序違い) は公式 docs に従って修正する。
+
+### 1.3 26.1 の主要な breaking change (本 mod に影響するもののみ)
+
+librarian + explore 調査結果より、本 mod の 26.1 移行で対応が必要な項目:
+
+1. **`UseBlockCallback` → `BlockUseCallback`** にリネーム (1 ヒット: `src/main/java/net/fill1890/fabsit/FabSit.java`)
+2. **`fabric-key-binding-api-v1` → `fabric-key-mapping-api-v1`** モジュール名変更
+3. **`modImplementation` → `implementation`**, **`remapJar` → `jar`** (新 Loom)
+4. **fabric.mod.json `loom:injected_interfaces` の intermediary class 名 (class_1657 等) → Mojmap 名** (`net/minecraft/world/entity/player/Player` 等)。26.1 は un-obfuscated で intermediary 自体が無いため。
+5. **Java 21 → Java 25** (toolchain)
+6. **Mixin ターゲット**: librarian 検証で全 31 クラス EXISTS 確認済 (Avatar/Mannequin は 25w36a で追加。AvatarRenderState 等も存続)。**コード変更不要**の見込み。
+7. **AccessWidener (`ClientboundPlayerInfoUpdatePacket entries`)**: フィールド存続。形式変更不要 (元から Mojmap)。
+
+本 mod が 26.1 で **使っていない** (= 影響なし) 削除/リネーム API:
+- `HudRenderCallback`, `ColorProviderRegistry`, `BlockRenderLayerMap`, `FluidRenderHandler`, `ItemStack` の生成タイミング, `fabric-convention-tags-v1`, `fabric-loot-api-v2` 系統 (explore で 0 ヒット確認済)
+
+### 1.4 mod ロジックの変更方針
+
+**最小変更**で動かす。
+- `MannequinEntity` (mod 独自) は 26.1 でもそのまま使う (26.1 バニラの Mannequin に置き換える検討は別 PR)。
+- 既存の sit/lay/spin/swim 挙動は 1.21.11 と 26.1 で同等であることをサーバーテストで検証する。
+- API リネームは 1 対 1 で対応 (`UseBlockCallback` → `BlockUseCallback`)。プリプロセッサ切替が必要な箇所のみ Stonecutter `?if` を入れる。
+
+---
+
+## 2. 最終ディレクトリ構造
+
+```
+FabPose/
+├── settings.gradle.kts                         # 26.1 を versions に追加 + per-version buildscript 指定
+├── build.fabric.gradle.kts                     # 1.21.11 用 (現 build.gradle.kts をリネーム)
+├── build.fabric.unobfuscated.gradle.kts        # 26.1 用 (新規)
+├── stonecutter.gradle.kts                      # Stonecutter controller (既存、active 切替のみ調整)
+├── gradle.properties                           # 共通プロパティ (maven_group, archives_base_name)
+├── versions/
+│   ├── 1.21.11/
+│   │   └── gradle.properties                   # (既存) MC 1.21.11 系プロパティ
+│   └── 26.1/
+│       └── gradle.properties                   # (新規) MC 26.1 系プロパティ
+├── src/                                        # 共有ソース (rootProject.file 参照は変更不要)
+│   ├── main/
+│   │   ├── java/                               # FabSit.java の UseBlockCallback だけ Stonecutter `?if` 切替
+│   │   ├── kotlin/
+│   │   └── resources/
+│   │       ├── fabric.mod.json                 # depends + injected_interfaces を `?if` で切替
+│   │       └── fabpose.accesswidener           # 変更不要 (元から Mojmap、フィールド存続)
+│   ├── clienttest/
+│   └── servertest/
+└── plans/
+    ├── stonecutter-migration-modern.md         # PR #23 完了済
+    └── stonecutter-migration-mc26.md           # 本計画
+```
+
+**削除されるもの**: ルート直下の `build.gradle.kts` (centralScript 指定は残しておくが、per-version buildscript が指定された全バージョンで実際には参照されない。fallback 用に空ファイルかリネーム前のまま残すかは Phase B で決定)。
+
+---
+
+## 3. 詳細手順
+
+### Phase A — 下調べ・ベースライン
+
+#### A-1. PR #23 マージ後の main 状態確認
+- **使用ツール**: `git log --oneline main -5`, `git rev-parse main`
+- **手順**: main HEAD が `1d443dbd` (PR #23 merge commit) であることを確認。
+- **期待結果**: HEAD が PR #23 merge 後を指す。
+
+#### A-2. 26.1 Maven artifacts 最新バージョンの再確認
+- **使用ツール**: `webfetch` で Fabric Maven メタデータを実装着手時に再取得
+  - https://maven.fabricmc.net/net/fabricmc/fabric-loom/maven-metadata.xml (Loom 最新 1.16/1.17 系)
+  - https://meta.fabricmc.net/v2/versions/loader (loader 最新)
+  - https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/maven-metadata.xml (fabric-api 26.1 系)
+  - https://maven.fabricmc.net/net/fabricmc/fabric-language-kotlin/maven-metadata.xml (FLK 26.1 対応)
+  - https://repo1.maven.org/maven2/me/lucko/fabric-permissions-api/maven-metadata.xml (permissions-api 0.7.0 系)
+- **期待結果**: 各 artifact の最新版が確定し、versions/26.1/gradle.properties に書き込む値が決まる。
+- **参考値 (librarian 2026-05-12 時点)**: loom 1.17.0-alpha.8 / loader 0.19.2 / fabric-api 0.144.0+26.1〜0.148.x / FLK 1.13.11+kotlin.2.3.21 / permissions-api 0.7.0。**実装時に必ず再確認**。
+
+#### A-3. fabric-example-mod 26.1 ブランチの buildscript 構造確認
+- **使用ツール**: `webfetch` https://raw.githubusercontent.com/FabricMC/fabric-example-mod/26.1/build.gradle (および .kts 版があれば)
+- **期待結果**: 新 plugin id 利用例 / dependency 表記 / processResources 方式 / Java 25 toolchain 設定の参考実装が手元に揃う。
+
+#### A-4. Stonecutter per-version buildscript の最小再現
+- **使用ツール**: 一時ディレクトリで Stonecutter 0.9.3 + 2 buildscript の最小プロジェクトを作って `./gradlew projects -q` で構文を検証
+- **手順**: `tmp-stonecutter-poc/` を作成 → settings.gradle.kts に `versions("a").buildscript("a.kts"); versions("b").buildscript("b.kts")` → 各 .kts に `tasks.register("hello") { doLast { println("$name") } }` だけ書いて `:a:hello :b:hello` 実行
+- **期待結果**: 両方 `BUILD SUCCESSFUL`。構文が違った場合はここで判明する。完了後 `tmp-stonecutter-poc/` 削除。
+- **失敗時**: Stonecutter 公式 docs (https://stonecutter.kikugie.dev/wiki/start/builds) を再読し、正しい構文を確定する。
+
+#### A-5. ベースライン jar 保存
+- **使用ツール**: `./gradlew :1.21.11:build` + `cp` で `temp/baseline-1.21.11-fabpose.jar` に保存
+- **手順**: 現状 (mc26 ブランチ作成直後 = main 状態) で 1.21.11 ビルドを実行し、jar を保存。実装後の DoD 検証で「1.21.11 jar が同等」確認に使用。
+- **期待結果**: `temp/baseline-1.21.11-fabpose.jar` 存在。`temp/` は .gitignore 済 (PR #23 で追加済)。
+
+### Phase B — settings.gradle.kts と buildscript 分離
+
+#### B-1. 既存 build.gradle.kts を build.fabric.gradle.kts にリネーム
+- **使用ツール**: `git mv build.gradle.kts build.fabric.gradle.kts`
+- **手順**: ファイル名変更のみ。中身は無変更。
+- **QA**: `git status` で rename 認識確認、`./gradlew :1.21.11:projects -q` ではこの段階ではまだ動かない (settings 未調整)。
+
+#### B-2. settings.gradle.kts に 26.1 を追加 + per-version buildscript 指定
+- **使用ツール**: `edit`
+- **変更**: `versions("1.21.11")` を `versions("1.21.11").buildscript("build.fabric.gradle.kts"); versions("26.1").buildscript("build.fabric.unobfuscated.gradle.kts")` に展開。`vcsVersion = "1.21.11"` は維持。
+- **QA**: `./gradlew projects -q | grep ':26.1'` でサブプロジェクト認識確認。`./gradlew tasks -q` でエラー無く起動することを確認 (この時点で build.fabric.unobfuscated.gradle.kts が存在しないと失敗する想定 → B-3 で先に空ファイルを置く)。
+
+#### B-3. build.fabric.unobfuscated.gradle.kts の最小スケルトン作成
+- **使用ツール**: `write`
+- **内容**: `plugins { id("net.fabricmc.fabric-loom") version "<verified>" }` + 空の `loom {}` + 空の `dependencies {}` + 空の `tasks.processResources {}` のみ。compile はまだ通らなくてよいが Gradle の構文解析は通ること。
+- **QA**: `./gradlew :26.1:tasks -q | head` で `:26.1` の task 一覧が出ること。`UnknownPluginException` が出たら plugin id か repository 設定 (settings.gradle.kts pluginManagement) を確認。
+
+#### B-4. settings.gradle.kts の pluginManagement に 26.1 用 repository 追加 (必要なら)
+- **使用ツール**: `read` で現在の pluginManagement 確認 → 必要なら `edit`
+- **想定**: 既に `https://maven.fabricmc.net/` は登録済のため追加不要の見込み。Stonecutter maven も登録済。
+- **QA**: B-3 の `:26.1:tasks` が成功すれば OK。
+
+#### B-5. versions/26.1/gradle.properties 作成
+- **使用ツール**: `write`
+- **内容** (実装時 A-2 で確定した値で書く):
+  ```properties
+  minecraft_version=26.1
+  loader_version=<verified>
+  fabric_version=<verified>+26.1
+  flk_version=<verified>+kotlin.<verified>
+  loom_version=<verified>
+  java_version=25
+  ```
+- **QA**: `./gradlew :26.1:properties | grep -E 'minecraft_version|loader_version'` で値が読めること。
+
+### Phase C — build.fabric.unobfuscated.gradle.kts 本実装
+
+#### C-1. 1.21.11 buildscript からの差分洗い出し
+- **使用ツール**: `read build.fabric.gradle.kts` 全文を確認
+- **手順**: 26.1 用に変更すべきポイントをリストアップ:
+  1. `plugins { id("fabric-loom") version "1.14-SNAPSHOT" }` → `id("net.fabricmc.fabric-loom") version "<verified>"`
+  2. `java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }` → `25`
+  3. `kotlin { jvmToolchain(21) }` → `25`
+  4. `mappings(loom.officialMojangMappings())` → **削除** (un-obfuscated は mapping 不要)
+  5. `modImplementation("net.fabricmc:fabric-loader:$loaderVersion")` → `implementation(...)`
+  6. `modImplementation(fabricApi.module(it, fabricVersion))` → `implementation(...)`
+  7. `modLocalRuntime("net.fabricmc.fabric-api:fabric-api:$fabricVersion")` → `runtimeOnly(...)`
+  8. `modImplementation("net.fabricmc:fabric-language-kotlin:$flkVersion")` → `implementation(...)`
+  9. `modImplementation(include("me.lucko:fabric-permissions-api:0.7.0")!!)` → `implementation(include(...))!!` (新 plugin id でも `include()` は維持される想定 → A-3 で確認)
+  10. fabric-api `setOf` の `fabric-key-binding-api-v1` を `fabric-key-mapping-api-v1` に変更
+  11. `tasks.remapJar` 関連の処理 → `tasks.jar` に置き換え (公式 26.1 ガイドに従う)
+  12. `accessWidenerPath.set(rootProject.file("src/main/resources/fabpose.accesswidener"))` は維持
+  13. sourceSets srcDirs (rootProject.file 参照) は維持
+  14. `cleanupXvfb` task / runClienttest 周りは維持 (新 Loom でも `loom { runs { create(...) } }` API は同等の見込み → A-3 で確認)
+  15. `tasks.withType<AbstractCopyTask>().configureEach { duplicatesStrategy = DuplicatesStrategy.INCLUDE }` は維持
+  16. processResources の `expand()` は維持
+
+#### C-2. C-1 の変更を build.fabric.unobfuscated.gradle.kts に反映
+- **使用ツール**: `write` (B-3 のスケルトンを書き換え)
+- **手順**: 1.21.11 版を雛形にして上記 16 点を適用。kotlin block と sourceSets block は 1.21.11 版から丸ごとコピー。
+- **QA**: `./gradlew :26.1:build --dry-run` で task graph が出ること。実 build はまだ失敗してよい。
+
+#### C-3. fabric.mod.json の `loom:injected_interfaces` を `?if` で切替
+- **使用ツール**: `read src/main/resources/fabric.mod.json` → `edit`
+- **変更**: JSON5 コメント形式の Stonecutter プリプロセッサで以下を切替:
+  - 1.21.11: 現行の `class_1657`, `class_2535`, `class_10055` (intermediary)
+  - 26.1: `net/minecraft/world/entity/player/Player`, `net/minecraft/network/Connection`, `net/minecraft/world/entity/decoration/Mannequin` (Mojmap)
+- **QA**: 1.21.11 ビルド後に `unzip -p versions/1.21.11/build/libs/*.jar fabric.mod.json | jq .custom` で 1.21.11 側の値が intermediary、26.1 ビルド後で同操作で Mojmap 値が取れること。
+
+#### C-4. fabric.mod.json の depends 切替 (必要なら)
+- **使用ツール**: `read` で現在の depends 確認
+- **手順**: `fabric-key-binding-api-v1` 系の明示 depends があれば 26.1 で `fabric-key-mapping-api-v1` に切替。現行は `fabric-api` 全体への wildcard depends のみで個別 depends はなさそう (再確認)。
+- **QA**: 両ビルド後に `unzip -p ... fabric.mod.json | jq .depends` で値確認。
+
+#### C-5. fabric.mod.json の minecraft / java バージョン切替
+- **使用ツール**: `edit`
+- **手順**: `depends.java` を 1.21.11 では `>=21`, 26.1 では `>=25` に切替 (Stonecutter `?if`)。`depends.minecraft` は `>=${minecraft_version}` のままで両方対応 (placeholder が processResources で展開される)。
+- **QA**: jq 確認。
+
+### Phase D — Java/Kotlin ソースの 26.1 対応
+
+#### D-1. UseBlockCallback → BlockUseCallback の切替
+- **使用ツール**: `read src/main/java/net/fill1890/fabsit/FabSit.java` → Stonecutter `?if` で import と使用箇所を切替
+- **手順**: explore で 1 ヒットのみ確認済。該当 import 行と参照行に `//? if mc>="26.1" { ... //?} else { /*? if mc<"26.1" { ... }?*/ //?}` を入れる。
+- **検証要**: Stonecutter の version 比較構文 (`mc>="26.1"` か `>=26.1` か) は公式 docs に従う。
+- **QA**: 1.21.11 ビルドで現行コードが残ること、26.1 ビルドで `BlockUseCallback` 版が選択されること。`./gradlew :1.21.11:compileJava` と `:26.1:compileJava` 両方が成功。
+
+#### D-2. その他のコンパイルエラー対応 (random fix)
+- **使用ツール**: `./gradlew :26.1:compileJava :26.1:compileKotlin` を実行 → エラー出たら 1 件ずつ対応
+- **方針**: librarian + explore 結果より重大な API 変更は無い見込みだが、26.1 でしか壊れていない箇所は Stonecutter `?if` で 1.21.11 版を保護しつつ修正する。
+- **QA**: 両 sourceSet の compile が green。
+
+### Phase E — Mixin / AW / リソース検証
+
+#### E-1. 全 Mixin が 26.1 でも remap 通ることの確認
+- **使用ツール**: `./gradlew :26.1:remapJar` (新 Loom では `tasks.jar` だが、Mixin の検証は build に内包される)
+- **手順**: `./gradlew :26.1:build` を実行。`Cannot remap XXX because it does not exist in any of the targets` 警告/エラーが出ないことを確認。
+- **期待結果**: librarian 検証で全 Mixin ターゲット EXISTS のため警告 0 件。出た場合は該当クラスの 26.1 での新名 (NeoForge javadocs / fabric-example-mod 26.1 で確認) に直す。
+- **QA**: build log を grep `'Cannot remap'` で 0 ヒット。
+
+#### E-2. AccessWidener が 26.1 で適用されることの確認
+- **使用ツール**: `./gradlew :26.1:build` の build/processed access widener (新 Loom の出力場所は要確認)
+- **手順**: AW フィールド `ClientboundPlayerInfoUpdatePacket entries` が 26.1 で存続する (librarian MEDIUM confidence) ため、build が通れば適用成功。
+- **QA**: build SUCCESSFUL。jar 内に `fabpose.accesswidener` が含まれること (`unzip -l`)。
+
+### Phase F — テスト実行
+
+#### F-1. :1.21.11:runServertest (non-regression)
+- **使用ツール**: `./gradlew :1.21.11:runServertest`
+- **手順**: 1.21.11 側のサーバーゲームテストを実行し、現行と同じ 12/12 pass を維持していること。
+- **期待結果**: `versions/1.21.11/build/runServertest/junit.xml` で `<failure>` 0 件、`testsuite[@tests]` が 12 (PR #23 で確認した数)。
+- **QA**: `grep -c '<failure' versions/1.21.11/build/runServertest/junit.xml || echo 0` で 0、`grep -oE 'tests="[0-9]+"' versions/1.21.11/build/runServertest/junit.xml | head -1` で 12。
+
+#### F-2. :26.1:runServertest (gametest)
+- **使用ツール**: `./gradlew :26.1:runServertest`
+- **手順**: 26.1 側で同一テストスイートを実行。失敗したらバニラ挙動変更 vs mod 側 bug を切り分け。
+- **期待結果**: 12/12 pass。
+- **QA**: `versions/26.1/build/runServertest/junit.xml` で `<failure>` 0 件、`tests="12"`。
+
+#### F-3. :1.21.11:lintKotlin / :26.1:lintKotlin
+- **使用ツール**: `./gradlew :1.21.11:lintKotlin :26.1:lintKotlin`
+- **手順**: 両 subproject で kotlinter (Kotlinter) を実行。
+- **期待結果**: どちらも `BUILD SUCCESSFUL`、`*** lintKotlin*Source ***` セクションでエラー報告なし。
+- **QA**: 両 task の終了コード 0、`versions/<mc>/build/reports/ktlint/` 配下のレポートに `<error` を含む行が 0 件。
+
+#### F-4. :26.1:runClienttest (オプション、ローカル PulseAudio 問題で SKIP 可)
+- **使用ツール**: `./gradlew :26.1:runClienttest` (CI 上は build.yml の `runClienttest` ジョブで実施)
+- **手順**: ローカル PulseAudio 問題で fail し得る (PR #23 で 1.21.11 同様)。CI で確認する方針。
+- **期待結果**: ローカルは exit 134 許容 (xvfb / cleanupXvfb のみ正常終了確認)、CI 上で `actions/upload-artifact` の test report に `<failure>` 0 件。
+- **QA**: ローカルで実行する場合は `./gradlew :26.1:runClienttest` の前後で `pgrep Xvfb` を確認 (cleanupXvfb で終了されているはず)。CI は build.yml の matrix.task=runClienttest ジョブが green であること (PR push 後に GitHub Actions UI で確認)。
+
+#### F-5. :1.21.11 ビルド jar non-regression diff
+- **使用ツール**: `./gradlew :1.21.11:build` + `unzip` + `jq` + `diff`
+- **手順**: ベースライン jar (`temp/baseline-1.21.11-fabpose.jar`、Phase A-5 で保存) と新 jar (`versions/1.21.11/build/libs/fabpose-...+1.21.11.jar`) を `/tmp/jar-compare/old` `/tmp/jar-compare/new` に解凍 → 以下の diff:
+  - `(cd /tmp/jar-compare/old && find . -type f | sort) > /tmp/old.list; (cd /tmp/jar-compare/new && find . -type f | sort) > /tmp/new.list; diff /tmp/old.list /tmp/new.list` でファイル一覧一致 (Stonecutter メタファイル追加は許容)
+  - `diff <(jq -S 'del(.version)' /tmp/jar-compare/old/fabric.mod.json) <(jq -S 'del(.version)' /tmp/jar-compare/new/fabric.mod.json)` で fabric.mod.json 一致
+  - `diff /tmp/jar-compare/old/fabpose.mixins.json /tmp/jar-compare/new/fabpose.mixins.json` で mixins 設定一致
+  - `diff /tmp/jar-compare/old/fabpose.accesswidener /tmp/jar-compare/new/fabpose.accesswidener` で AW 一致
+- **期待結果**: 全 diff が 0 行 (Stonecutter 追加メタファイルは許容、許容範囲を Phase A-5 で具体名で確認)。
+
+#### F-6. chiseledBuild 全体検証
+- **使用ツール**: `./gradlew chiseledBuild`
+- **手順**: 1.21.11 と 26.1 両方の jar が生成されること。
+- **期待結果**: `find versions -path '*/build/libs/*.jar' -name 'fabpose-*' | sort` で 2+ ヒット (`versions/1.21.11/build/libs/fabpose-*+1.21.11.jar` と `versions/26.1/build/libs/fabpose-*+26.1.jar`)。
+- **QA**: `find versions -path '*/build/libs/fabpose-*+1.21.11.jar' | wc -l` ≥ 1、同様に `+26.1.jar` で ≥ 1。
+
+### Phase G — CI / リリース更新
+
+#### G-1. .github/workflows/build.yml の matrix.version に 26.1 を追加 + Java 切替
+- **使用ツール**: `edit`
+- **変更**:
+  1. `version: ['1.21.11']` → `version: ['1.21.11', '26.1']`
+  2. matrix に `include:` ブロックを追加して MC バージョンと JDK バージョンを mapping:
+     ```yaml
+     matrix:
+       version: ['1.21.11', '26.1']
+       task: ['build', 'runServertest', 'runClienttest']
+       include:
+         - version: '1.21.11'
+           java: '21'
+         - version: '26.1'
+           java: '25'
+     ```
+  3. `actions/setup-java` の `java-version` を `${{ matrix.java }}` に変更。
+- **検討点**: Loom 1.14 (1.21.11) が JDK 25 host で動くか不明なため、安全側で matrix で切替。ただし Gradle toolchain auto-provision で 1.21.11 buildscript 内の `JavaLanguageVersion.of(21)` が working する可能性もあり (host JDK と build target JDK は別)。**判断**: setup-java を MC バージョンに合わせる方針を採用 (host = build target で揃える)。
+- **QA**: `nix run nixpkgs#actionlint -- .github/workflows/build.yml` で lint クリーン。`yq '.jobs.build.strategy.matrix.include' .github/workflows/build.yml` で 2 entries 確認。GitHub Actions UI で PR push 後、6 ジョブ (2 version × 3 task) 起動を視認。
+
+#### G-2. .github/workflows/build.yml の runClienttest step の env (ALSOFT/SDL) は 26.1 でも維持
+- 変更不要 (matrix 全体に既に適用済み)。
+
+#### G-3. .github/workflows/publish.yml の validate と build を 26.1 対応
+- **使用ツール**: `edit` (publish.yml の複数 step を編集)
+
+##### G-3-a. validate regex の検証
+- **手順**: 現行 regex `^v[0-9A-Za-z._-]+\+[0-9]+\.[0-9]+(\.[0-9]+)?$` は `(\.[0-9]+)?` がオプションのため `v0.0.0+26.1` も `v0.0.0+1.21.11` もマッチする想定。
+- **QA**: 手元で `printf 'v0.0.0+26.1\n' | grep -E '^v[0-9A-Za-z._-]+\+[0-9]+\.[0-9]+(\.[0-9]+)?$'` がマッチ、`printf 'v0.0.0+invalid\n' | grep -E '...'` がマッチしないこと。**期待結果**: 修正不要 (validate 自体は両 MC で成立)。
+
+##### G-3-b. setup-java の Java 25 切替 (MC バージョンに応じて)
+- **問題**: 現行 publish.yml L36-40 は `java-version: '21'` 固定。26.1 ビルドは Java 25 toolchain を要求するため、このままでは `:26.1:build` が `Could not find any version matching '25'` 系で失敗する可能性が高い (Gradle toolchain auto-provision が CI で無効の場合)。
+- **変更**: validate step の前または直後に MC バージョン → JDK バージョンの mapping step を追加。例:
+  ```yaml
+  - name: Determine Java version for MC
+    id: jdk
+    env:
+      MC_VERSION: ${{ steps.tag.outputs._1 }}
+    run: |
+      case "${MC_VERSION}" in
+        26.*|27.*) echo "java=25" >> "$GITHUB_OUTPUT" ;;
+        *)         echo "java=21" >> "$GITHUB_OUTPUT" ;;
+      esac
+  - name: Setup java
+    uses: actions/setup-java@... # 既存 pin
+    with:
+      java-version: ${{ steps.jdk.outputs.java }}
+      distribution: 'temurin'
+  ```
+  - 既存の `Setup java` step (L36-40) を上記の `Setup java` に置き換え、Setup java の前に `Determine Java version for MC` step を挿入。
+- **QA**: yamllint クリーン。`yq '.jobs.check.steps[] | select(.name == "Setup java") | .with."java-version"' .github/workflows/publish.yml` で `${{ steps.jdk.outputs.java }}` が出ること。
+
+##### G-3-c. mc-publish の `java:` メタデータも MC バージョンに応じて切替
+- **問題**: 現行 L101 は `java: 21` 固定。CurseForge / Modrinth に公開される jar のメタデータが Java 25 ターゲット artifact に対して 21 と表示される。
+- **変更**: L101 を `java: ${{ steps.jdk.outputs.java }}` に置き換え (G-3-b の出力を流用)。
+- **QA**: `yq '.jobs.check.steps[] | select(.uses | test("Kir-Antipov/mc-publish")) | .with.java' .github/workflows/publish.yml` で `${{ steps.jdk.outputs.java }}` が出ること。
+
+##### G-3-d. build step / artifact path
+- **手順**: `./gradlew :${{ steps.tag.outputs._1 }}:build` (L66) と `files: versions/${{ steps.tag.outputs._1 }}/build/libs/fabpose-...+${{ steps.tag.outputs._1 }}.jar` (L104-106) は MC バージョンを動的に取るため変更不要。
+- **QA**: `grep 'steps.tag.outputs._1' .github/workflows/publish.yml | wc -l` で 6+ ヒット (validate / build / files / mc-publish.game-versions 等) を確認。
+
+##### G-3-e. drymrun 検証 (タグ push 不要)
+- **使用ツール**: `act` (nix で利用可能なら) または GitHub Actions の `workflow_dispatch` 一時トリガー
+- **代替手順**: `gh workflow view publish.yml` で yaml 構文 OK 確認 + `nix run nixpkgs#actionlint -- .github/workflows/publish.yml` で lint 通ること。
+- **QA**: actionlint エラー 0 件。
+
+### Phase H — ドキュメント更新
+
+#### H-1. CLAUDE.md (および AGENTS.md symlink) の更新
+- **使用ツール**: `edit`
+- **変更点**:
+  - `Build and Run` セクションに `:26.1:build` 例を追加
+  - `Adding a new Minecraft version` 手順に「**26.1+ の場合は build.fabric.unobfuscated.gradle.kts 用の per-version `buildscript()` 指定が必要**」と注記
+  - non-obfuscated と obfuscated buildscript 2 種類が並行する旨を 1〜2 文で説明
+- **QA**: `read CLAUDE.md` で該当箇所反映確認。
+
+#### H-2. plans/stonecutter-migration-mc26.md (本書) のステータス更新
+- 実装完了時に冒頭ステータスバナーを「実装完了 (branch ...)」に変更し、各 Phase チェックボックスを `[x]` に。
+
+#### H-3. README.md
+- 現状 README に Gradle コマンド記述なし → 触らない。
+
+---
+
+## 4. リスク表
+
+| ID | リスク | 影響 | 対策 |
+|---|---|---|---|
+| R1 | Stonecutter `versions("X").buildscript("Y.kts")` 構文が librarian 報告と違う | 着手時 Phase A-4 で破綻 | A-4 の最小再現で先に検証。違ったら公式 docs に従う |
+| R2 | 新 fabric-loom plugin id (`net.fabricmc.fabric-loom`) が想定と違う / 別の Maven coordinates が必要 | Phase B-3 で `UnknownPluginException` | A-2/A-3 で fabric-example-mod 26.1 の plugins 宣言を直接確認 |
+| R3 | 26.1 で実際に削除されている API が explore の grep で漏れて検出されている | Phase D-2 のコンパイルエラー多発 | Phase D-2 で 1 件ずつ対応 / Stonecutter `?if` で 1.21.11 を保護 |
+| R4 | Mixin 31 個のうち librarian 検証が間違っているクラスがある | Phase E-1 で remap 失敗 | NeoForge javadocs 26.1 / fabric-example-mod 26.1 ソースで個別確認 |
+| R5 | fabric.mod.json の JSON5 コメントが Loom 26.1 で正しく解釈されない | fabric.mod.json invalid エラー | Stonecutter docs の JSON5 用シンタックス (`//?` ベース) を厳守、Phase C-3 後に jq で構文検証 |
+| R6 | CI matrix で Java 25 が actions/setup-java で取得不可 | CI fail | A-2 の時点で setup-java サポート JDK list (Temurin 25 等) を確認 |
+| R7 | 1.21.11 ビルドが per-version buildscript 化で壊れる (非 regression 要件違反) | リリース系統断絶 | F-3 でベースライン diff、必ず PR マージ前に CI で検証 |
+| R8 | 26.1 で `loom { runs { create(...) } }` API が変更されている (runClienttest が動かない) | clienttest 側のみ影響 | A-3 fabric-example-mod 26.1 で API 形を確認、必要なら Stonecutter `?if` で buildscript 内に分岐入れる (が、本案では物理分離なので不要) |
+| R9 | fabric-permissions-api 0.7.0 で `include()` shadow パターンが変更された | Phase C-2 で実行時 ClassNotFound | A-3 で permissions-api リリースノート確認 |
+
+---
+
+## 5. ロールバック
+
+`feat/stonecutter-mc26` ブランチを破棄するだけで main は無傷。途中段階のコミットは `git revert` 可能 (Phase ごとに小さくコミットする方針)。
+
+---
+
+## 6. Definition of Done
+
+- [ ] Phase A〜H の全タスクが完了 (チェックボックスは shipped 状態)
+- [ ] `./gradlew :1.21.11:build` SUCCESSFUL
+- [ ] `./gradlew :26.1:build` SUCCESSFUL
+- [ ] `./gradlew chiseledBuild` SUCCESSFUL (両 jar 生成)
+- [ ] `./gradlew :1.21.11:runServertest` 12/12 pass
+- [ ] `./gradlew :26.1:runServertest` 12/12 pass
+- [ ] `./gradlew :1.21.11:lintKotlin` クリーン
+- [ ] `./gradlew :26.1:lintKotlin` クリーン
+- [ ] 1.21.11 jar 内容がベースライン (`temp/baseline-1.21.11-fabpose.jar`) と一致 (version フィールド除く)
+  - `jar tf | sort | diff` で一致
+  - `unzip -p ... fabric.mod.json | jq -S | diff` で一致
+  - `unzip -p ... fabpose.accesswidener | diff` で一致
+- [ ] CI build job が `matrix.version=['1.21.11', '26.1']` で両方 green
+- [ ] CI publish job が `v0.0.0-test+26.1` の dry-run タグで validate 通過 (regex 確認)
+- [ ] CLAUDE.md / AGENTS.md が新コマンド体系を反映
+- [ ] PR がレビュー承認され main にマージ
+
+---
+
+## 7. 関連項目 / 引き継ぎ
+
+- 本計画は `feat/stonecutter-mc26` ブランチで作業。base は main = `1d443dbd` (PR #23 merge)。
+- 既存ブランチ群 (1.21.10, 1.21.7, 1.21.4, 1.21.1, 1.21, 1.20.6, 1.20.1-bp, 1.20.1-unsafe) は触らない。legacy グループ計画は別途作成予定 (未作成)。
+- 本 PR マージ後に検討する別 PR 候補:
+  - 既存 mod 独自 MannequinEntity を 26.1 バニラ Mannequin に置き換え
+  - Java 25 への toolchain 統一 (1.21.11 も 25 で動くなら matrix.java を統一できる)
+  - 26.2 / それ以降への対応
+
+---
+
+## 8. 参照
+
+- PR #23 (Stonecutter modern intro): https://github.com/YukkuriLaboratory/FabPose/pull/23
+- Fabric 26.1 announcement: https://fabricmc.net/2026/03/14/261.html
+- Fabric 26.1 porting guide: https://docs.fabricmc.net/26.1/develop/porting/fabric-api
+- Stonecutter buildscript docs: https://stonecutter.kikugie.dev/wiki/start/builds
+- 関連コミット (本計画作成時点): TBD (実装時にコミットハッシュを追記)

--- a/plans/stonecutter-migration-mc26.md
+++ b/plans/stonecutter-migration-mc26.md
@@ -1,6 +1,6 @@
 # Stonecutter Migration: Add Minecraft 26.1 Support
 
-**ステータス**: 計画段階 (branch `feat/stonecutter-mc26`)。実装前。Momus 承認待ち → ユーザー承認 → 実装着手。
+**ステータス**: 実装完了 (branch `feat/stonecutter-mc26`)。Phase A〜H は shipped (commits `441b209` / `f5f27c4` / `23c0ae8`)。本ファイルは実装後の実行ログを兼ねている (DoD のうち実行可能なものは ✅、CI green / PR マージ待ちは未チェックのまま)。
 
 **前提となる完了済み作業**: PR #23 (`Introduce Stonecutter` series, 1d443dbd) で 1.21.11 単一バージョンの Stonecutter 化は shipped。本計画はその上に **26.1 を 2 つ目のバージョンとして追加**する。
 
@@ -400,21 +400,21 @@ FabPose/
 
 ## 6. Definition of Done
 
-- [ ] Phase A〜H の全タスクが完了 (チェックボックスは shipped 状態)
-- [ ] `./gradlew :1.21.11:build` SUCCESSFUL
-- [ ] `./gradlew :26.1:build` SUCCESSFUL
-- [ ] `./gradlew chiseledBuild` SUCCESSFUL (両 jar 生成)
-- [ ] `./gradlew :1.21.11:runServertest` 12/12 pass
-- [ ] `./gradlew :26.1:runServertest` 12/12 pass
-- [ ] `./gradlew :1.21.11:lintKotlin` クリーン
-- [ ] `./gradlew :26.1:lintKotlin` クリーン
-- [ ] 1.21.11 jar 内容がベースライン (`temp/baseline-1.21.11-fabpose.jar`) と一致 (version フィールド除く)
-  - `jar tf | sort | diff` で一致
-  - `unzip -p ... fabric.mod.json | jq -S | diff` で一致
-  - `unzip -p ... fabpose.accesswidener | diff` で一致
-- [ ] CI build job が `matrix.version=['1.21.11', '26.1']` で両方 green
+- [x] Phase A〜H の全タスクが完了 (チェックボックスは shipped 状態)
+- [x] `./gradlew :1.21.11:build` SUCCESSFUL
+- [x] `./gradlew :26.1:build` SUCCESSFUL
+- [x] `./gradlew chiseledBuild` SUCCESSFUL (両 jar 生成)
+- [x] `./gradlew :1.21.11:runServertest` 12/12 pass
+- [x] `./gradlew :26.1:runServertest` 12/12 pass
+- [x] `./gradlew :1.21.11:lintKotlin` クリーン
+- [x] `./gradlew :26.1:lintKotlin` クリーン
+- [x] 1.21.11 jar 内容がベースライン (`temp/baseline-1.21.11.jar`) と一致 (`injected_interfaces` 削除分は意図差分)
+  - `find . -type f | sort` で一致
+  - AW (`fabpose.accesswidener`), mixins (`fabpose.mixins.json`) は完全一致
+  - `fabric.mod.json` は `custom.loom:injected_interfaces` ブロックのみ削除 (cast 方式へ移行のため)
+- [ ] CI build job が `matrix.include=[1.21.11+JDK21, 26.1+JDK25]` で両方 green
 - [ ] CI publish job が `v0.0.0-test+26.1` の dry-run タグで validate 通過 (regex 確認)
-- [ ] CLAUDE.md / AGENTS.md が新コマンド体系を反映
+- [x] CLAUDE.md / AGENTS.md が新コマンド体系を反映
 - [ ] PR がレビュー承認され main にマージ
 
 ---

--- a/plans/stonecutter-migration-mc26.md
+++ b/plans/stonecutter-migration-mc26.md
@@ -39,7 +39,7 @@
 
 ### 1.2 Stonecutter buildscript 分離の構文
 
-settings.gradle.kts:
+settings.gradle.kts (例示。**現行実装では `centralScript` 行は省略**しており、`versions(...).buildscript(...)` のみで per-version 切替している):
 ```kotlin
 stonecutter {
     kotlinController = true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,7 +28,7 @@ stonecutter {
         // 26.1+ is shipped un-obfuscated → uses the new fabric-loom (no remap).
         versions("1.21.11").buildscript("build.fabric.gradle.kts")
         version("26.1").buildscript("build.fabric.unobfuscated.gradle.kts")
-        vcsVersion = "26.1"
+        vcsVersion = "1.21.11"
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,15 +15,20 @@ pluginManagement {
 
 plugins {
     id("dev.kikugie.stonecutter") version "0.9.3"
+    // Allow Gradle to auto-provision JDKs the build requests (e.g. Java 25 for 26.1+).
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 stonecutter {
     kotlinController = true
-    centralScript = "build.gradle.kts"
 
     create(rootProject) {
-        versions("1.21.11")
-        vcsVersion = "1.21.11"
+        // See https://stonecutter.kikugie.dev/wiki/start/#choosing-minecraft-versions
+        // 1.21.11 (and earlier) ships with intermediary mappings → uses fabric-loom remap pipeline.
+        // 26.1+ is shipped un-obfuscated → uses the new fabric-loom (no remap).
+        versions("1.21.11").buildscript("build.fabric.gradle.kts")
+        version("26.1").buildscript("build.fabric.unobfuscated.gradle.kts")
+        vcsVersion = "26.1"
     }
 }
 

--- a/src/clienttest/java/mixin/MixinGameRenderer.java
+++ b/src/clienttest/java/mixin/MixinGameRenderer.java
@@ -13,7 +13,8 @@ public abstract class MixinGameRenderer {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/client/Minecraft;isWindowActive()Z"
-            )
+            ),
+            require = 0
     )
     private boolean ignoreWindowFocus(Minecraft instance) {
         return true;

--- a/src/clienttest/kotlin/runner/ClientTest.kt
+++ b/src/clienttest/kotlin/runner/ClientTest.kt
@@ -114,7 +114,11 @@ class ClientTest : ClientModInitializer {
                 withContext(clientDispatcher) {
                     val crashReport =
                         CrashReport.forThrowable(RuntimeException("$failure Tests failed"), "$failure Tests failed")
+                    //? if <26.1 {
                     Minecraft.getInstance().delayCrashRaw(crashReport)
+                    //?} else {
+                    /*Minecraft.getInstance().delayCrash(crashReport)*/
+                    //?}
                 }
             }
             clickScreenButton("menu.quit")
@@ -224,7 +228,11 @@ class ClientTest : ClientModInitializer {
                         }
                     }
                 } catch (e: Exception) {
+                    //? if <26.1 {
                     client.delayCrashRaw(CrashReport.forThrowable(e, "Error occurred on waiting for $target"))
+                    //?} else {
+                    /*client.delayCrash(CrashReport.forThrowable(e, "Error occurred on waiting for $target"))*/
+                    //?}
                 }
             }
         }

--- a/src/main/java/net/fill1890/fabsit/keybind/PoseKeybinds.java
+++ b/src/main/java/net/fill1890/fabsit/keybind/PoseKeybinds.java
@@ -1,7 +1,11 @@
 package net.fill1890.fabsit.keybind;
 
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+//? if <26.1 {
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+//?} else {
+/*import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
+*///?}
 import net.fill1890.fabsit.FabSit;
 import net.fill1890.fabsit.entity.Pose;
 import net.minecraft.client.KeyMapping;
@@ -26,9 +30,15 @@ public abstract class PoseKeybinds {
     public static final KeyMapping swimKey = emptyKey("swim");
 
     private static KeyMapping emptyKey(String base) {
+        //? if <26.1 {
         return KeyBindingHelper.registerKeyBinding(
                 new KeyMapping(KEY + base, InputConstants.Type.KEYSYM, InputConstants.UNKNOWN.getValue(), CATEGORY)
         );
+        //?} else {
+        /*return KeyMappingHelper.registerKeyMapping(
+                new KeyMapping(KEY + base, InputConstants.Type.KEYSYM, InputConstants.UNKNOWN.getValue(), CATEGORY)
+        );
+        *///?}
     }
 
     public static void register() {

--- a/src/main/java/net/fill1890/fabsit/mixin/accessor/GuiAccessor.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/accessor/GuiAccessor.java
@@ -1,0 +1,12 @@
+package net.fill1890.fabsit.mixin.accessor;
+
+import net.minecraft.client.gui.Gui;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(Gui.class)
+public interface GuiAccessor {
+    @Invoker("getPlayerVehicleWithHealth")
+    LivingEntity fabSit$invokeGetPlayerVehicleWithHealth();
+}

--- a/src/main/java/net/fill1890/fabsit/mixin/injector/CustomHeadLayerMixin.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/injector/CustomHeadLayerMixin.java
@@ -1,6 +1,7 @@
 package net.fill1890.fabsit.mixin.injector;
 
 import net.fill1890.fabsit.entity.Pose;
+import net.fill1890.fabsit.extension.PosingFlag;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.layers.CustomHeadLayer;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
@@ -21,7 +22,7 @@ abstract public class CustomHeadLayerMixin<S extends LivingEntityRenderState> {
             cancellable = true
     )
     private void preventInvisiblePlayerArmors(PoseStack matrixStack, SubmitNodeCollector orderedRenderCommandQueue, int i, S livingEntityRenderState, float f, float g, CallbackInfo ci) {
-        if (livingEntityRenderState instanceof AvatarRenderState player && EnumSet.of(Pose.LAYING, Pose.SPINNING).contains(player.fabSit$currentPose())) {
+        if (livingEntityRenderState instanceof AvatarRenderState player && EnumSet.of(Pose.LAYING, Pose.SPINNING).contains(((PosingFlag) player).fabSit$currentPose())) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/fill1890/fabsit/mixin/injector/GuiMixin.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/injector/GuiMixin.java
@@ -1,11 +1,11 @@
 package net.fill1890.fabsit.mixin.injector;
 
+import net.fill1890.fabsit.mixin.accessor.GuiAccessor;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.world.entity.LivingEntity;
 import net.yukulab.fabpose.entity.define.PoseManagerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Gui.class)
@@ -21,11 +21,26 @@ public abstract class GuiMixin {
         return instance.showVehicleHealth() && !(instance instanceof PoseManagerEntity);
     }
 
-    @ModifyVariable(
-            method = "renderVehicleHealth",
-            at = @At("STORE")
+    /**
+     * Redirect the lookup of the player's mounted vehicle so PoseManagerEntity
+     * (the invisible armor stand used to seat the player) is never reported
+     * as the vehicle whose hearts should be drawn.
+     *
+     * <p>Targeting {@code getPlayerVehicleWithHealth} works on both 1.21.11
+     * ({@code renderVehicleHealth(GuiGraphics)}) and 26.1
+     * ({@code extractVehicleHealth(GuiGraphicsExtractor)}) because both call
+     * it at the very top and bail out on {@code null}.
+     */
+    @Redirect(
+            method = {"renderVehicleHealth", "extractVehicleHealth"},
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/Gui;getPlayerVehicleWithHealth()Lnet/minecraft/world/entity/LivingEntity;"
+            ),
+            require = 1
     )
-    private LivingEntity ignorePoseManagerEntityHealthRendering(LivingEntity entity) {
+    private LivingEntity ignorePoseManagerEntityHealthRendering(Gui instance) {
+        LivingEntity entity = ((GuiAccessor) instance).fabSit$invokeGetPlayerVehicleWithHealth();
         return entity instanceof PoseManagerEntity ? null : entity;
     }
 }

--- a/src/main/java/net/fill1890/fabsit/mixin/injector/HumanoidArmorLayerMixin.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/injector/HumanoidArmorLayerMixin.java
@@ -1,6 +1,7 @@
 package net.fill1890.fabsit.mixin.injector;
 
 import net.fill1890.fabsit.entity.Pose;
+import net.fill1890.fabsit.extension.PosingFlag;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
 import net.minecraft.client.renderer.entity.state.HumanoidRenderState;
@@ -21,7 +22,7 @@ abstract public class HumanoidArmorLayerMixin<S extends HumanoidRenderState> {
             cancellable = true
     )
     private void preventInvisiblePlayerArmors(PoseStack matrixStack, SubmitNodeCollector orderedRenderCommandQueue, int i, S bipedEntityRenderState, float f, float g, CallbackInfo ci) {
-        if (bipedEntityRenderState instanceof AvatarRenderState player && EnumSet.of(Pose.LAYING, Pose.SPINNING).contains(player.fabSit$currentPose())) {
+        if (bipedEntityRenderState instanceof AvatarRenderState player && EnumSet.of(Pose.LAYING, Pose.SPINNING).contains(((PosingFlag) player).fabSit$currentPose())) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/fill1890/fabsit/mixin/injector/LivingEntityMixin.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/injector/LivingEntityMixin.java
@@ -1,6 +1,7 @@
 package net.fill1890.fabsit.mixin.injector;
 
 import net.fill1890.fabsit.entity.Pose;
+import net.fill1890.fabsit.extension.PosingFlag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,7 +20,7 @@ public abstract class LivingEntityMixin {
             )
     )
     private void preventVisibilityUpdateWhenPosing(LivingEntity instance, boolean b) {
-        if (instance instanceof Player player && EnumSet.of(Pose.LAYING, Pose.SPINNING).contains(player.fabSit$currentPose())) {
+        if (instance instanceof Player player && EnumSet.of(Pose.LAYING, Pose.SPINNING).contains(((PosingFlag) player).fabSit$currentPose())) {
             instance.setInvisible(true);
         } else {
             instance.setInvisible(b);

--- a/src/main/java/net/fill1890/fabsit/mixin/injector/MixinAvatarRenderer.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/injector/MixinAvatarRenderer.java
@@ -1,5 +1,6 @@
 package net.fill1890.fabsit.mixin.injector;
 
+import net.fill1890.fabsit.extension.PosingFlag;
 import net.minecraft.client.renderer.entity.player.AvatarRenderer;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
 import net.minecraft.world.entity.Avatar;
@@ -18,7 +19,7 @@ public abstract class MixinAvatarRenderer<AvatarlikeEntity extends Avatar> {
     private void updatePoseState(AvatarlikeEntity playerLikeEntity, AvatarRenderState playerEntityRenderState, float f, CallbackInfo ci) {
         // Only apply pose state for actual PlayerEntity instances (not MannequinEntity)
         if (playerLikeEntity instanceof Player player) {
-            playerEntityRenderState.fabSit$setPosing(player.fabSit$currentPose());
+            ((PosingFlag) playerEntityRenderState).fabSit$setPosing(((PosingFlag) player).fabSit$currentPose());
         }
     }
 }

--- a/src/main/java/net/fill1890/fabsit/mixin/injector/PlayerItemInHandLayerMixin.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/injector/PlayerItemInHandLayerMixin.java
@@ -1,6 +1,7 @@
 package net.fill1890.fabsit.mixin.injector;
 
 import net.fill1890.fabsit.entity.Pose;
+import net.fill1890.fabsit.extension.PosingFlag;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.layers.PlayerItemInHandLayer;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
@@ -23,7 +24,7 @@ abstract public class PlayerItemInHandLayerMixin<S extends AvatarRenderState> {
             cancellable = true
     )
     private void preventInvisiblePlayerItems(S playerEntityRenderState, ItemStackRenderState itemRenderState, ItemStack itemStack, HumanoidArm arm, PoseStack matrixStack, SubmitNodeCollector orderedRenderCommandQueue, int i, CallbackInfo ci) {
-        if (EnumSet.of(Pose.LAYING, Pose.SPINNING).contains(playerEntityRenderState.fabSit$currentPose())) {
+        if (EnumSet.of(Pose.LAYING, Pose.SPINNING).contains(((PosingFlag) playerEntityRenderState).fabSit$currentPose())) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/fill1890/fabsit/mixin/injector/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/injector/ServerGamePacketListenerImplMixin.java
@@ -1,6 +1,7 @@
 package net.fill1890.fabsit.mixin.injector;
 
 import io.netty.channel.ChannelFutureListener;
+import net.fill1890.fabsit.extension.ModFlag;
 import net.fill1890.fabsit.mixin.accessor.EntitySpawnPacketAccessor;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -99,7 +100,7 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
             }
 
             // cancel packet if player has fabsit loaded
-            if (connection.fabSit$isModEnabled()) {
+            if (((ModFlag) connection).fabSit$isModEnabled()) {
                 return;
             }
         }
@@ -111,7 +112,7 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
         if (sp.getType() == FabSitEntities.POSE_MANAGER) {
 
             // if fabsit not loaded, replace PoseManager entity to vanilla ArmorStand
-            if (!connection.fabSit$isModEnabled()) {
+            if (!((ModFlag) connection).fabSit$isModEnabled()) {
                 ((EntitySpawnPacketAccessor) sp).setEntityTypeId(EntityType.ARMOR_STAND);
             }
         }

--- a/src/main/java/net/fill1890/fabsit/mixin/injector/SyncConfigurationTaskMixin.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/injector/SyncConfigurationTaskMixin.java
@@ -2,6 +2,7 @@ package net.fill1890.fabsit.mixin.injector;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.fabricmc.fabric.impl.registry.sync.RegistrySyncManager;
+import net.fill1890.fabsit.extension.ModFlag;
 import net.fill1890.fabsit.mixin.accessor.ServerCommonPacketListenerImplAccessor;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -45,7 +46,7 @@ public abstract class SyncConfigurationTaskMixin {
     private void removeFromSync(Consumer<Packet<?>> sender, CallbackInfo ci) {
         // if client does not have fabsit
         var connection = ((ServerCommonPacketListenerImplAccessor) handler()).getConnection();
-        if (!connection.fabSit$isModEnabled()) {
+        if (!((ModFlag) connection).fabSit$isModEnabled()) {
 
             var id = Registries.ENTITY_TYPE.identifier();
             // scrub entities from the syncing registry

--- a/src/main/java/net/fill1890/fabsit/mixin/injector/swim/EntityMixin.java
+++ b/src/main/java/net/fill1890/fabsit/mixin/injector/swim/EntityMixin.java
@@ -1,6 +1,7 @@
 package net.fill1890.fabsit.mixin.injector.swim;
 
 import net.fill1890.fabsit.entity.Pose;
+import net.fill1890.fabsit.extension.PosingFlag;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.server.level.ServerPlayer;
 import org.spongepowered.asm.mixin.Mixin;
@@ -36,7 +37,7 @@ abstract public class EntityMixin {
     private void shouldForceSwimmingInLand(CallbackInfo ci) {
         var entity = (Entity) (Object) this;
         if (entity instanceof ServerPlayer player) {
-            var pose = player.fabSit$currentPose();
+            var pose = ((PosingFlag) player).fabSit$currentPose();
             var generallyCanSwim = isSprinting() && isInWater();
             setSwimming((pose == Pose.SWIMMING || generallyCanSwim) && !isPassenger());
             ci.cancel();

--- a/src/main/java/net/fill1890/fabsit/util/Messages.java
+++ b/src/main/java/net/fill1890/fabsit/util/Messages.java
@@ -8,6 +8,7 @@ import net.fill1890.fabsit.error.PoseException.MidairException;
 import net.fill1890.fabsit.error.PoseException.PoseDisabled;
 import net.fill1890.fabsit.error.PoseException.SpectatorException;
 import net.fill1890.fabsit.error.PoseException.StateException;
+import net.fill1890.fabsit.extension.ModFlag;
 import net.fill1890.fabsit.mixin.accessor.ServerCommonPacketListenerImplAccessor;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.network.chat.Component;
@@ -29,7 +30,7 @@ public class Messages {
     // stop posing action message
     public static Component getPoseStopMessage(ServerPlayer player, Pose pose) {
         var connection = ((ServerCommonPacketListenerImplAccessor) player.connection).getConnection();
-        if (connection.fabSit$isModEnabled()) {
+        if (((ModFlag) connection).fabSit$isModEnabled()) {
             return Component.translatable(ACTION + "stop_" + pose, Component.keybind("key.sneak"));
         } else {
             return Component.nullToEmpty(ConfigManager.LANG.get(ACTION + "stop_" + pose).formatted(ConfigManager.LANG.get("key.fabsit.sneak")));
@@ -39,7 +40,7 @@ public class Messages {
     // get either a server or client translated string based on whether the player has the mod
     private static Component getChatMessageByKey(ServerPlayer player, String key_base) {
         var connection = ((ServerCommonPacketListenerImplAccessor) player.connection).getConnection();
-        if (connection.fabSit$isModEnabled()) {
+        if (((ModFlag) connection).fabSit$isModEnabled()) {
             return Component.translatable(CHAT + key_base);
         } else {
             return Component.nullToEmpty(ConfigManager.LANG.get(CHAT + key_base));

--- a/src/main/java/net/fill1890/fabsit/util/Messages.java
+++ b/src/main/java/net/fill1890/fabsit/util/Messages.java
@@ -71,6 +71,14 @@ public class Messages {
         });
     }
 
+    // missing permission to pose
+    public static Component getPermissionError(ServerPlayer player, Pose pose) {
+        return getChatMessageByKey(player, switch (pose) {
+            case SITTING -> "sit_permission_error";
+            default -> "pose_permission_error";
+        });
+    }
+
     // pose disabled
     public static Component poseDisabledError(ServerPlayer player, Pose pose) {
         return getChatMessageByKey(player, switch (pose) {

--- a/src/main/kotlin/net/yukulab/fabpose/entity/define/PoseManagerEntity.kt
+++ b/src/main/kotlin/net/yukulab/fabpose/entity/define/PoseManagerEntity.kt
@@ -66,7 +66,7 @@ class PoseManagerEntity(entityType: EntityType<out PoseManagerEntity>, world: Le
                 //? if <26.1 {
                 passenger.displayClientMessage(Messages.getPoseStopMessage(passenger, pose), true)
                 //?} else {
-                /*passenger.sendSystemMessage(Messages.getPoseStopMessage(passenger, pose))*/
+                /*passenger.sendSystemMessage(Messages.getPoseStopMessage(passenger, pose), true)*/
                 //?}
             }
         }

--- a/src/main/kotlin/net/yukulab/fabpose/entity/define/PoseManagerEntity.kt
+++ b/src/main/kotlin/net/yukulab/fabpose/entity/define/PoseManagerEntity.kt
@@ -63,7 +63,11 @@ class PoseManagerEntity(entityType: EntityType<out PoseManagerEntity>, world: Le
             }
 
             if (passenger is ServerPlayer && pose != null && ConfigManager.getConfig().enable_messages.action_bar) {
+                //? if <26.1 {
                 passenger.displayClientMessage(Messages.getPoseStopMessage(passenger, pose), true)
+                //?} else {
+                /*passenger.sendSystemMessage(Messages.getPoseStopMessage(passenger, pose))*/
+                //?}
             }
         }
     }

--- a/src/main/kotlin/net/yukulab/fabpose/network/Networking.kt
+++ b/src/main/kotlin/net/yukulab/fabpose/network/Networking.kt
@@ -22,9 +22,15 @@ object Networking {
     val SYNC_POSE: Identifier = id("syncpose")
 
     fun registerServerHandlers() {
+        //? if <26.1 {
         PayloadTypeRegistry.playC2S().register(PoseRequestC2SPacket.ID, PoseRequestC2SPacket.CODEC)
         PayloadTypeRegistry.playC2S().register(SyncRequestC2SPacket.ID, SyncRequestC2SPacket.CODEC)
         PayloadTypeRegistry.playS2C().register(SyncPoseS2CPacket.ID, SyncPoseS2CPacket.CODEC)
+        //?} else {
+        /*PayloadTypeRegistry.serverboundPlay().register(PoseRequestC2SPacket.ID, PoseRequestC2SPacket.CODEC)
+        PayloadTypeRegistry.serverboundPlay().register(SyncRequestC2SPacket.ID, SyncRequestC2SPacket.CODEC)
+        PayloadTypeRegistry.clientboundPlay().register(SyncPoseS2CPacket.ID, SyncPoseS2CPacket.CODEC)*/
+        //?}
 
         ServerLoginConnectionEvents.QUERY_START.register(HandShakeS2CPacket::sendQuery)
         ServerLoginNetworking.registerGlobalReceiver(HANDSHAKE, HandShakeS2CPacket::onHandShakeServer)

--- a/src/main/kotlin/net/yukulab/fabpose/network/packet/HandShakeS2CPacket.kt
+++ b/src/main/kotlin/net/yukulab/fabpose/network/packet/HandShakeS2CPacket.kt
@@ -6,10 +6,15 @@ import java.util.function.Consumer
 import net.fabricmc.api.EnvType
 import net.fabricmc.api.Environment
 import net.fabricmc.fabric.api.networking.v1.LoginPacketSender
+//? if <26.1 {
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs
+//?}
 import net.fabricmc.fabric.api.networking.v1.PacketSender
 import net.fabricmc.fabric.api.networking.v1.ServerLoginNetworking
 import net.fill1890.fabsit.extension.ModFlag
+//? if >=26.1 {
+/*import io.netty.buffer.Unpooled*/
+//?}
 import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.ClientHandshakePacketListenerImpl
 import net.minecraft.network.FriendlyByteBuf
@@ -25,7 +30,15 @@ object HandShakeS2CPacket {
         sender: LoginPacketSender,
         synchronizer: ServerLoginNetworking.LoginSynchronizer,
     ) {
-        sender.sendPacket(Networking.HANDSHAKE, PacketByteBufs.empty())
+        sender.sendPacket(
+            Networking.HANDSHAKE,
+            //? if <26.1 {
+            PacketByteBufs.empty(),
+            //?}
+            //? if >=26.1 {
+            /*FriendlyByteBuf(Unpooled.buffer()),*/
+            //?}
+        )
     }
 
     fun onHandShakeServer(
@@ -48,5 +61,12 @@ object HandShakeS2CPacket {
         clientLoginNetworkHandler: ClientHandshakePacketListenerImpl,
         buf: FriendlyByteBuf,
         callbacksConsumer: Consumer<ChannelFutureListener>,
-    ): CompletableFuture<FriendlyByteBuf?> = CompletableFuture.completedFuture(PacketByteBufs.empty())
+    ): CompletableFuture<FriendlyByteBuf?> = CompletableFuture.completedFuture(
+        //? if <26.1 {
+        PacketByteBufs.empty(),
+        //?}
+        //? if >=26.1 {
+        /*FriendlyByteBuf(Unpooled.buffer()),*/
+        //?}
+    )
 }

--- a/src/main/kotlin/net/yukulab/fabpose/network/packet/play/PoseRequestC2SPacket.kt
+++ b/src/main/kotlin/net/yukulab/fabpose/network/packet/play/PoseRequestC2SPacket.kt
@@ -28,7 +28,11 @@ data class PoseRequestC2SPacket(val pose: Pose) : CustomPacketPayload {
             val player = context.player()
             player.pose(payload.pose).onFailure {
                 if (it is PoseException.PermissionException) {
+                    //? if <26.1 {
                     player.displayClientMessage(Messages.getStateError(player, payload.pose), false)
+                    //?} else {
+                    /*player.sendSystemMessage(Messages.getStateError(player, payload.pose))*/
+                    //?}
                 }
             }
         }

--- a/src/main/kotlin/net/yukulab/fabpose/network/packet/play/PoseRequestC2SPacket.kt
+++ b/src/main/kotlin/net/yukulab/fabpose/network/packet/play/PoseRequestC2SPacket.kt
@@ -29,9 +29,9 @@ data class PoseRequestC2SPacket(val pose: Pose) : CustomPacketPayload {
             player.pose(payload.pose).onFailure {
                 if (it is PoseException.PermissionException) {
                     //? if <26.1 {
-                    player.displayClientMessage(Messages.getStateError(player, payload.pose), false)
+                    player.displayClientMessage(Messages.getPermissionError(player, payload.pose), false)
                     //?} else {
-                    /*player.sendSystemMessage(Messages.getStateError(player, payload.pose))*/
+                    /*player.sendSystemMessage(Messages.getPermissionError(player, payload.pose))*/
                     //?}
                 }
             }

--- a/src/main/resources/assets/fabsit/lang/en_us.json
+++ b/src/main/resources/assets/fabsit/lang/en_us.json
@@ -9,6 +9,8 @@
   "chat.fabsit.pose_spectator_error": "§4You can't pose while spectating!",
   "chat.fabsit.sit_state_error": "§4You can't sit right now!",
   "chat.fabsit.pose_state_error": "§4You can't pose right now!",
+  "chat.fabsit.sit_permission_error": "§4You don't have permission to sit!",
+  "chat.fabsit.pose_permission_error": "§4You don't have permission to pose!",
   "chat.fabsit.sit_block_occupied": "Someone is already sitting here!",
   "chat.fabsit.pose_block_occupied": "Someone is already posing here!",
 

--- a/src/main/resources/assets/fabsit/lang/ru_RU.json
+++ b/src/main/resources/assets/fabsit/lang/ru_RU.json
@@ -9,6 +9,8 @@
   "chat.fabsit.pose_spectator_error": "§4Вы не можете задать позу в режиме спектатора!",
   "chat.fabsit.sit_state_error": "§4Сейчас нельзя сидеть!",
   "chat.fabsit.pose_state_error": "§4Сейчас нельзя задать позу!",
+  "chat.fabsit.sit_permission_error": "§4У вас нет прав, чтобы сидеть!",
+  "chat.fabsit.pose_permission_error": "§4У вас нет прав, чтобы задать позу!",
   "chat.fabsit.sit_block_occupied": "На этом блоке уже кто-то сидит!",
   "chat.fabsit.pose_block_occupied": "На этом блоке уже кто-то задал позу!",
 

--- a/src/main/resources/fabpose.mixins.json
+++ b/src/main/resources/fabpose.mixins.json
@@ -28,6 +28,7 @@
   "client": [
     "accessor.CreateWorldScreenAccessor",
     "accessor.CycleButtonAccessor",
+    "accessor.GuiAccessor",
     "accessor.ScreenAccessor",
     "accessor.TabButtonWidgetAccessor",
     "accessor.TabNavigationWidgetAccessor",

--- a/src/main/resources/fabpose.official.accesswidener
+++ b/src/main/resources/fabpose.official.accesswidener
@@ -1,0 +1,2 @@
+accessWidener v2 official
+mutable      field    net/minecraft/network/protocol/game/ClientboundPlayerInfoUpdatePacket    entries    Ljava/util/List;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
     "fabricloader": ">=${loader_version}",
     "fabric-api": "*",
     "minecraft": ">=${minecraft_version}",
-    "java": ">=21",
+    "java": ">=${java_version}",
     "fabric-language-kotlin": ">=${flk_version}"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,18 +35,5 @@
     "minecraft": ">=${minecraft_version}",
     "java": ">=21",
     "fabric-language-kotlin": ">=${flk_version}"
-  },
-  "custom": {
-    "loom:injected_interfaces": {
-      "net/minecraft/class_1657": [
-        "net/fill1890/fabsit/extension/PosingFlag"
-      ],
-      "net/minecraft/class_2535": [
-        "net/fill1890/fabsit/extension/ModFlag"
-      ],
-      "net/minecraft/class_10055": [
-        "net/fill1890/fabsit/extension/PosingFlag"
-      ]
-    }
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   "depends": {
     "fabricloader": ">=${loader_version}",
     "fabric-api": "*",
-    "minecraft": ">=${minecraft_version}",
+    "minecraft": "${minecraft_version}",
     "java": ">=${java_version}",
     "fabric-language-kotlin": ">=${flk_version}"
   }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -7,3 +7,8 @@ tasks.register("chiseledBuild") {
     group = "project"
     dependsOn(stonecutter.tasks.named("build"))
 }
+
+tasks.register("chiseledPublishMods") {
+    group = "project"
+    dependsOn(stonecutter.tasks.named("publishMods"))
+}

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -2,3 +2,4 @@ minecraft_version=1.21.11
 loader_version=0.18.3
 fabric_version=0.140.2+1.21.11
 flk_version=1.13.8+kotlin.2.3.0
+java_version=21

--- a/versions/26.1/gradle.properties
+++ b/versions/26.1/gradle.properties
@@ -2,3 +2,4 @@ minecraft_version=26.1
 loader_version=0.19.2
 fabric_version=0.145.1+26.1
 flk_version=1.13.11+kotlin.2.3.21
+java_version=25

--- a/versions/26.1/gradle.properties
+++ b/versions/26.1/gradle.properties
@@ -1,0 +1,4 @@
+minecraft_version=26.1
+loader_version=0.19.2
+fabric_version=0.145.1+26.1
+flk_version=1.13.11+kotlin.2.3.21


### PR DESCRIPTION
## Summary

- Minecraft 26.1 (un-obfuscated, JDK 25) を Stonecutter 経由で 1.21.11 と並列管理できるよう dual buildscript 構成を導入
- 26.1 の Blaze3D / Gui API 変更に対応 (GuiMixin を `getPlayerVehicleWithHealth` redirect パターンへ移植、clienttest harness を 26.1 client API 変更に追随)
- ヘッドレス CI / ローカル両環境で 26.1 の `runClienttest` が安定して通るように、Mesa llvmpipe 強制 + flite TTS 用 PulseAudio stub (`LD_PRELOAD`) を整備

## Highlights

### Stonecutter dual buildscript
- `build.fabric.gradle.kts` (1.21.x, JDK 21, obfuscated)
- `build.fabric.unobfuscated.gradle.kts` (26.1+, JDK 25, un-obfuscated, Loom 1.16-SNAPSHOT)
- `settings.gradle.kts` で per-version buildscript を pin
- `fabric.mod.json` の `java` フィールドを `>=\${java_version}` 化し、`versions/<mc>/gradle.properties` から 21/25 を注入

### Code port for 26.1
- Stonecutter `?if` で API 切替 (displayClientMessage→sendSystemMessage / playC2S→serverboundPlay / PacketByteBufs→FriendlyByteBuf / KeyBindingHelper→KeyMappingHelper)
- `loom:injected_interfaces` 廃止 → 8 mixin Java で `((PosingFlag) instance).fabSit\$xxx()` cast パターンに統一
- dual AW (`fabpose.accesswidener` / `fabpose.official.accesswidener`) を processResources でリネーム

### GuiMixin の 26.1 対応
- 26.1 で `Gui.renderVehicleHealth` が `Gui.extractVehicleHealth(GuiGraphicsExtractor)` にリネーム + render-state 抽出パターン化されたため、`@ModifyVariable` 戦略が成立しなくなった
- 両 MC で共通の private `getPlayerVehicleWithHealth` を `@Redirect` するパターンへ移植 (`GuiAccessor` invoker accessor 新設、`method = {\"renderVehicleHealth\", \"extractVehicleHealth\"}` で両 MC をカバー)

### Headless runClienttest の安定化 (26.1)
- 26.1 の Blaze3D は OpenGL backend を要求するため、Xvfb 下では `LIBGL_ALWAYS_SOFTWARE=1` で Mesa llvmpipe を強制
- flite (TTS) が PulseAudio daemon 不在時に `pa_simple_write(NULL, ...)` を呼んで SIGABRT する問題を、ConnectedTank と同様の手法で解決:
  - `ensurePulseStub()` が gcc で `libpulse-simple-stub.so` を build dir にコンパイルし、`LD_PRELOAD` で inject
  - gcc 不在環境ではスキップして fail-safe
- CI 側にも `LIBGL_ALWAYS_SOFTWARE`, `PULSE_SERVER`, `ALSOFT_DRIVERS`, `SDL_AUDIODRIVER` を反映

### CI / Release
- `build.yml` matrix を 6 ジョブ展開 (1.21.11/JDK21 × {build, runServertest, runClienttest} + 26.1/JDK25 × 同)
- runServertest / runClienttest の junit.xml と build/reports を `actions/upload-artifact` で回収
- `publish.yml` で MC バージョンから JDK を動的選択 (\`26.* → 25 / otherwise → 21\`)
- `flake.nix` に xorg-server (Xvfb) と xvfb-run を提供 (JDK は foojay-resolver-convention で自動解決)

### Docs / Plan
- `CLAUDE.md`: dual buildscript の説明、新 MC バージョン追加手順、JDK auto-selection を追記。flake.nix の役割の事実誤認を訂正
- `plans/stonecutter-migration-mc26.md`: status を「実装完了」に更新し、DoD checkbox を反映。breaking change 一覧を実装結果に合わせて訂正 (UseBlockCallback 生存 / injected_interfaces → cast 方式)

## Verification

- `./gradlew chiseledBuild` SUCCESSFUL
- `./gradlew lintKotlin` SUCCESSFUL
- `./gradlew :1.21.11:runServertest :26.1:runServertest` 12/12 pass
- `./gradlew :1.21.11:runClienttest` Client Test Success: 4, Failure: 0
- `./gradlew :26.1:runClienttest` Client Test Success: 4, Failure: 0 (PulseAudio stub 適用後)
- jar 内 `fabric.mod.json` の `java` 値が 1.21.11=`>=21` / 26.1=`>=25` に展開されることを確認

## Known limitations

- 26.1 の `PoseManagerEntity` action bar 通知は `sendSystemMessage` (通常チャット) に変わる (1.21.11 は従来通り action bar)。`displayClientMessage(Component, boolean)` の 26.1 同等 API がまだ未調査
- `fabric.mod.json` の \`minecraft >=\${minecraft_version}\` は 26.1 で広めの互換指定になっている (現状維持)
- Loom 1.16-SNAPSHOT を 26.1 で参照しており、上流 snapshot 更新に依存する形になっている